### PR TITLE
fixes identation error, fix twilio parameters condition

### DIFF
--- a/securetea/core.py
+++ b/securetea/core.py
@@ -93,9 +93,12 @@ class SecureTea(object):
             except:
                 print('Telegram configuration parameters not set')    
                 
-            if cred['twilio']:
+            try:
+                cred['twilio']
                 self.twilio_provided = True
-
+                cred_provided = True
+            except:
+                print('Twilio configuration parameters not set')
 
         if not cred:
             print('Config not found')

--- a/securetea/secureTeaTelegram.py
+++ b/securetea/secureTeaTelegram.py
@@ -26,7 +26,7 @@ class SecureTeaTelegram():
     enabled = True
 
     def __init__(self, cred, debug):
-    	"""Init logger params.
+        """Init logger params.
 
         Args:
             modulename (str): Script module name


### PR DESCRIPTION
References #21 
The PR fixes indentation error for Python3
Also fixes the conditional statement in case Twilio arguments aren't provided.

I have tested the application on `python3.6.7` as well as `python2.7` , it works fine. :+1:  