### PR TITLE
CLI configuration & interactive setup for Firewall

### DIFF
--- a/securetea.conf
+++ b/securetea.conf
@@ -20,7 +20,7 @@
 		"user_id": "XXXX"
 	},
 	"firewall": {
-		"interface": "None",
+		"interface": "",
 		"inbound_IPRule": {
 			"action": "0",
 			"ip_inbound": ""

--- a/securetea/args/args_helper.py
+++ b/securetea/args/args_helper.py
@@ -15,6 +15,72 @@ Project:
 import platform
 from securetea import logger
 import sys
+import json
+
+
+def iterate_dict(config_dict, default):
+    """
+    Recursively iterate over the config_dict and
+    take inputs.
+
+    Args:
+        config_dict (dict): configuraton dict
+        default (dict): default configuration dict
+
+    Raises:
+        None
+
+    Returns:
+        None: if setup is skipped
+        dict: if user provides value to all the inputs
+    """
+    skip = False
+    for key, item in config_dict.items():
+        if not skip:
+            if type(item) is not dict:
+                if int(platform.sys.version_info[0]) < 3:  # if Python 2.X.X
+                    val = raw_input('>> Enter {}: '
+                                    .format(item)).strip()
+                else:
+                    val = str(input('>> Enter {}: '
+                              .format(item))).strip()
+                if (val == 's' or
+                    val == 'S'):
+                    skip = True
+                    return None
+                elif val == '':
+                    config_dict[key] = default[key]
+                else:
+                    config_dict[key] = val
+            else:
+                sub_dict = iterate_dict(config_dict[key],
+                                        default[key])
+                if sub_dict is not None:
+                    config_dict[key] = sub_dict
+                else:
+                    return None
+        else:
+            return None
+    return config_dict
+
+
+def load_default(key):
+    """
+    Load default configuration.
+
+    Args:
+        key (str): Find credentials for this key
+
+    Raises:
+        None
+
+    Returns:
+        cred (dict): Default configuration
+    """
+    path = 'securetea.conf'
+    with open(path) as f:
+        creds = json.load(f)
+        return creds[key]
 
 
 class ArgsHelper(object):
@@ -37,6 +103,7 @@ class ArgsHelper(object):
         self.telegram_provided = False
         self.twilio_provided = False
         self.slack_provided = False
+        self.firewall_provided = False
 
         # Setup logger
         self.logger = logger.SecureTeaLogger(
@@ -48,7 +115,9 @@ class ArgsHelper(object):
         r"""
         Decorator function to make taking inputs easier
         in different versions of Python. It also adds
-        functionality to skip taking inputs.
+        functionality to skip taking inputs, iterate over
+        nested dictionary, have a default fall back configuraton
+        if user provides a NULL value.
 
         Usage:
         ------
@@ -76,28 +145,14 @@ class ArgsHelper(object):
         --------
         dict: User entered values
         """
-        def inner_wrapper(*args, **kwargs):
-            skip = False
-            config_dict = func(*args, **kwargs)
+        def inner_wrapper(*args):
             print('\n[!] Enter (S/s) to skip...')
-            for key, item in config_dict.items():
-                if not skip:
-                    if int(platform.sys.version_info[0]) < 3:  # if Python 2.X.X
-                        config_dict[key] = raw_input('>> Enter {}: '
-                                                     .format(item)).strip()
-                        if (config_dict[key] == 's' or
-                            config_dict[key] == 'S'):
-                            skip = True
-                    else:
-                        config_dict[key] = str(input('>> Enter {}: '
-                                                     .format(item))).strip()
-                        if (config_dict[key] == 's' or
-                            config_dict[key] == 'S'):
-                            skip = True
-            if not skip:
-                return config_dict
-            else:
-                return None
+            dict_value = func(*args)
+            config_dict = dict_value['input']
+            default = dict_value['default']
+            config_dict = iterate_dict(config_dict,
+                                       default)
+            return config_dict
         return inner_wrapper
 
     @takeInput
@@ -106,11 +161,15 @@ class ArgsHelper(object):
         Returns the format to configure Twitter
         """
         self.logger.log('Twitter configuration setup')
+        default = load_default('twitter')
         return {
-            'api_secret_key': 'twitter api secret key',
-            'api_key': 'twitter api key',
-            'access_token': 'twitter access token',
-            'access_token_secret': 'twitter access token secret'
+            'input': {
+                'api_secret_key': 'twitter api secret key',
+                'api_key': 'twitter api key',
+                'access_token': 'twitter access token',
+                'access_token_secret': 'twitter access token secret'
+            },
+            'default': default
         }
 
     @takeInput
@@ -119,9 +178,13 @@ class ArgsHelper(object):
         Returns the format to configure Telegram
         """
         self.logger.log('Telegram configuration setup')
+        default = load_default('telegram')
         return {
-            'token': 'telegram bot token',
-            'user_id': 'telegram user id'
+            'input': {
+                'token': 'telegram bot token',
+                'user_id': 'telegram user id'
+            },
+            'default': default
         }
 
     @takeInput
@@ -130,11 +193,15 @@ class ArgsHelper(object):
         Returns the format to configure Twilio
         """
         self.logger.log('Twilio configuration setup')
+        default = load_default('twilio')
         return {
-            'twilio_sid': 'twilio SID',
-            'twilio_token': 'twilio token',
-            'twilio_from': 'twilio (from) phone number',
-            'twilio_to': 'twilio (to) phone number'
+            'input': {
+                'twilio_sid': 'twilio SID',
+                'twilio_token': 'twilio token',
+                'twilio_from': 'twilio (from) phone number',
+                'twilio_to': 'twilio (to) phone number'
+            },
+            'default': default
         }
 
     @takeInput
@@ -143,15 +210,71 @@ class ArgsHelper(object):
         Returns the format to configure Slack
         """
         self.logger.log('Slack configuraton setup')
+        default = load_default('slack')
         return {
-            'token': 'slack token',
-            'user_id': 'slack user id'
+            'input': {
+                'token': 'slack token',
+                'user_id': 'slack user id'
+            },
+            'default': default
+        }
+
+    @takeInput
+    def configureFirewall(self):
+        """
+        Returns the format to configure Firewall.
+        """
+        self.logger.log('Firewall configuration setup')
+        default = load_default('firewall')
+        return {
+            'input': {
+                "interface": "interface name",
+            	"inbound_IPRule": {
+            		"action": "inbound IP action (0: BLOCK, 1: ALLOW)",
+            		"ip_inbound": "list of inbound IPs to look for"
+            	},
+            	"outbound_IPRule": {
+            		"action": "outbound IP action (0: BLOCK, 1: ALLOW)",
+            		"ip_outbound": "list of outbound IPs to look for"
+            	},
+            	"protocolRule": {
+            		"action": "protocol action (0: BLOCK, 1: ALLOW)",
+            		"protocols": "list of protocols to look for"
+            	},
+            	"scanLoad": {
+            		"action": "scan download action (0: BLOCK, 1: ALLOW)",
+            		"extensions": "list of extensions to scan for"
+            	},
+            	"source_portRule": {
+            		"action": "source port action (0: BLOCK, 1: ALLOW)",
+            		"sports": "list of source ports"
+            	},
+            	"dest_portRule": {
+            		"action": "destination port action (0: BLOCK, 1: ALLOW)",
+            		"dports": "list of destination ports"
+            	},
+            	"HTTPRequest": {
+            		"action": "HTTP request action (0: BLOCK, 1: ALLOW)"
+            	},
+            	"HTTPResponse": {
+            		"action": "HTTP response action (0: BLOCK, 1: ALLOW)"
+            	},
+            	"DNSRule": {
+            		"action": "DNS action (0: BLOCK, 1: ALLOW)",
+            		"dns": "list of dns to look for"
+            	},
+            	"time": {
+            		"time_lb": "time lower bound (eg. 00:00)",
+            		"time_ub": "time upper bound (eg. 23:59)"
+            	}
+            },
+            'default': default
         }
 
     def check_args(self):
         """
-        This function parses the args, checks the configuration
-        and calls the required configuration setup accordingly.
+        Parse the args, check the configuration
+        and call the required configuration setup accordingly.
 
         Args:
         -----
@@ -165,7 +288,8 @@ class ArgsHelper(object):
         --------
         dict:
         """
-        if len(sys.argv) == 1:  # Peform all integration
+        if ((len(sys.argv) == 1) or
+           (len(sys.argv) == 2 and self.args.debug)):  # Peform all integration
 
             # Start the twitter configuration setup
             twitter = self.configureTwitter()
@@ -191,6 +315,12 @@ class ArgsHelper(object):
                 self.cred['slack'] = slack
                 self.slack_provided = True
 
+            # Start the firewall configuration setup
+            firewall = self.configureFirewall()
+            if firewall:
+                self.cred['firewall'] = firewall
+                self.firewall_provided = True
+
         if self.args.twitter and not self.twitter_provided:
             twitter = self.configureTwitter()
             if twitter:
@@ -215,9 +345,17 @@ class ArgsHelper(object):
                 self.cred['slack'] = slack
                 self.slack_provided = True
 
+        if self.args.firewall and not self.firewall_provided:
+            firewall = self.configureFirewall()
+            if firewall:
+                self.cred['firewall'] = firewall
+                self.firewall_provided = True
+
         if not self.twitter_provided:
-            if (self.args.twitter_api_key and self.args.twitter_api_secret_key and
-                self.args.twitter_access_token and self.args.twitter_access_token_secret):
+            if (self.args.twitter_api_key and
+                self.args.twitter_api_secret_key and
+                self.args.twitter_access_token and
+                self.args.twitter_access_token_secret):
                 twitter = {}
                 twitter['api_key'] = self.args.twitter_api_key
                 twitter['api_secret_key'] = self.args.twitter_api_secret_key
@@ -227,7 +365,8 @@ class ArgsHelper(object):
                 self.twitter_provided = True
 
         if not self.telegram_provided:
-            if (self.args.telegram_bot_token and self.args.telegram_user_id):
+            if (self.args.telegram_bot_token and
+                self.args.telegram_user_id):
                 telegram = {}
                 telegram['token'] = self.args.telegram_bot_token
                 telegram['user_id'] = self.args.telegram_user_id
@@ -235,8 +374,10 @@ class ArgsHelper(object):
                 self.telegram_provided = True
 
         if not self.twilio_provided:
-            if (self.args.twilio_sid and self.args.twilio_token and
-                self.args.twilio_from and self.args.twilio_to):
+            if (self.args.twilio_sid and
+                self.args.twilio_token and
+                self.args.twilio_from and
+                self.args.twilio_to):
                 twilio = {}
                 twilio['twilio_sid'] = self.args.twilio_sid
                 twilio['twilio_token'] = self.args.twilio_token
@@ -246,15 +387,87 @@ class ArgsHelper(object):
                 self.twilio_provided = True
 
         if not self.slack_provided:
-            if (self.args.slack_user_id and self.args.slack_token):
+            if (self.args.slack_user_id and
+                self.args.slack_token):
                 slack = {}
                 slack['token'] = self.args.slack_token
                 slack['user_id'] = self.args.slack_user_id
                 self.cred['slack'] = slack
                 self.slack_provided = True
 
-        if (self.twitter_provided or self.telegram_provided or
-            self.twilio_provided or self.slack_provided):
+        if not self.firewall_provided:
+            if (self.args.interface and
+                self.args.inbound_IP_action and
+                self.args.inbound_IP_list and
+                self.args.outbound_IP_action and
+                self.args.outbound_IP_list and
+                self.args.protocol_action and
+                self.args.protocol_list and
+                self.args.scan_action and
+                self.args.scan_list and
+                self.args.dest_port_action and
+                self.args.dest_port_list and
+                self.args.source_port_action and
+                self.args.source_port_list and
+                self.args.dns_action and
+                self.args.dns_list and
+                self.args.HTTP_request_action and
+                self.args.HTTP_response_action and
+                self.args.time_lb and
+                self.args.time_ub):
+
+                # Initialize empty firewall configuraton dictionary
+                firewall = {}
+
+                # Create configuration dictionary
+                firewall['interface'] = self.args.interface
+                firewall['inbound_IPRule'] = {
+                                    'action': self.args.inbound_IP_action,
+                                    'ip_inbound': self.args.inbound_IP_list
+                                }
+                firewall['outbound_IPRule'] = {
+                                    'action': self.args.outbound_IP_action,
+                                    'ip_outbound': self.args.outbound_IP_list
+                                }
+                firewall['protocolRule'] = {
+                                    'action': self.args.protocol_action,
+                                    'protocols': self.args.protocol_list
+                                }
+                firewall['scanLoad'] = {
+                                    'action': self.args.scan_action,
+                                    'extensions': self.args.scan_list
+                                }
+                firewall['source_portRule'] = {
+                                    'action': self.args.source_port_action,
+                                    'sports': self.args.source_port_list
+                                }
+                firewall['dest_portRule'] = {
+                                    'action': self.args.dest_port_action,
+                                    'dports': self.args.dest_port_list
+                                }
+                firewall['HTTPRequest'] = {
+                                    'action': self.args.HTTP_request_action
+                                }
+                firewall['HTTPResponse'] = {
+                                    'action': self.args.HTTP_response_action
+                                }
+                firewall['DNSRule'] = {
+                                'action': self.args.dns_action,
+                                'dns': self.args.dns_list
+                            }
+                firewall['time'] = {
+                            'time_lb': self.args.time_lb,
+                            'time_ub': self.args.time_ub
+                        }
+
+                self.cred['firewall'] = firewall
+                self.firewall_provided = True
+
+        if (self.twitter_provided or
+            self.telegram_provided or
+            self.twilio_provided or
+            self.slack_provided or
+            self.firewall_provided):
             self.cred_provided = True
 
         return {
@@ -263,5 +476,6 @@ class ArgsHelper(object):
             'twitter_provided': self.twitter_provided,
             'telegram_provided': self.telegram_provided,
             'twilio_provided': self.twilio_provided,
-            'slack_provided': self.slack_provided
+            'slack_provided': self.slack_provided,
+            'firewall_provided': self.firewall_provided
         }

--- a/securetea/args/args_helper.py
+++ b/securetea/args/args_helper.py
@@ -37,7 +37,7 @@ def iterate_dict(config_dict, default):
     skip = False
     for key, item in config_dict.items():
         if not skip:
-            if type(item) is not dict:
+            if not isinstance(item, dict):
                 if int(platform.sys.version_info[0]) < 3:  # if Python 2.X.X
                     val = raw_input('>> Enter {}: '
                                     .format(item)).strip()

--- a/securetea/args/args_helper.py
+++ b/securetea/args/args_helper.py
@@ -83,6 +83,51 @@ def load_default(key):
         return creds[key]
 
 
+def takeInput(func):
+    r"""
+    Decorator function to make taking inputs easier
+    in different versions of Python. It also adds
+    functionality to skip taking inputs, iterate over
+    nested dictionary, have a default fall back configuraton
+    if user provides a NULL value.
+
+    Usage:
+    ------
+    Put @takeInput over which ever function you want to decorate.
+
+    >> @takeInput
+       def configureApp():
+           return {
+                'token_name': 'token description'  # this is what gets printed on the screen
+           }
+
+    Output:
+    -------
+    >> Enter token description: <user enters value>
+
+    Working:
+    --------
+    User entered value is stored as: {token_name : 'user_entered_value'}
+
+    Raises:
+    -------
+    None
+
+    Returns:
+    --------
+    dict: User entered values
+    """
+    def inner_wrapper(*args):
+        print('\n[!] Enter (S/s) to skip...')
+        dict_value = func(*args)
+        config_dict = dict_value['input']
+        default = dict_value['default']
+        config_dict = iterate_dict(config_dict,
+                                   default)
+        return config_dict
+    return inner_wrapper
+
+
 class ArgsHelper(object):
 
     def __init__(self, args):
@@ -110,50 +155,6 @@ class ArgsHelper(object):
             self.modulename,
             self.cred['debug']
         )
-
-    def takeInput(func):
-        r"""
-        Decorator function to make taking inputs easier
-        in different versions of Python. It also adds
-        functionality to skip taking inputs, iterate over
-        nested dictionary, have a default fall back configuraton
-        if user provides a NULL value.
-
-        Usage:
-        ------
-        Put @takeInput over which ever function you want to decorate.
-
-        >> @takeInput
-           def configureApp():
-               return {
-                    'token_name': 'token description'  # this is what gets printed on the screen
-               }
-
-        Output:
-        -------
-        >> Enter token description: <user enters value>
-
-        Working:
-        --------
-        User entered value is stored as: {token_name : 'user_entered_value'}
-
-        Raises:
-        -------
-        None
-
-        Returns:
-        --------
-        dict: User entered values
-        """
-        def inner_wrapper(*args):
-            print('\n[!] Enter (S/s) to skip...')
-            dict_value = func(*args)
-            config_dict = dict_value['input']
-            default = dict_value['default']
-            config_dict = iterate_dict(config_dict,
-                                       default)
-            return config_dict
-        return inner_wrapper
 
     @takeInput
     def configureTwitter(self):

--- a/securetea/args/arguments.py
+++ b/securetea/args/arguments.py
@@ -168,5 +168,137 @@ def get_args():
         help='Start firewall'
     )
 
+    parser.add_argument(
+        '--interface',
+        required=False,
+        help='Name of the interface'
+    )
+
+    parser.add_argument(
+        '--inbound_IP_action',
+        type=str,
+        required=False,
+        help='Inbound IP rule action'
+    )
+
+    parser.add_argument(
+        '--inbound_IP_list',
+        type=str,
+        required=False,
+        help='List of inbound IPs to look for'
+    )
+
+    parser.add_argument(
+        '--outbound_IP_action',
+        type=str,
+        required=False,
+        help='Outbound IP rule action (0: BLOCK, 1: ALLOW)'
+    )
+
+    parser.add_argument(
+        '--outbound_IP_list',
+        type=str,
+        required=False,
+        help='List of outbound IPs to look for'
+    )
+
+    parser.add_argument(
+        '--protocol_action',
+        type=str,
+        required=False,
+        help='Protocol action (0: BLOCK, 1: ALLOW)'
+    )
+
+    parser.add_argument(
+        '--protocol_list',
+        type=str,
+        required=False,
+        help='List of protocols to look for'
+    )
+
+    parser.add_argument(
+        '--scan_action',
+        type=str,
+        required=False,
+        help='Scan load action (0: BLOCK, 1: ALLOW)'
+    )
+
+    parser.add_argument(
+        '--scan_list',
+        type=str,
+        required=False,
+        help='List of extensions to scan for'
+    )
+
+    parser.add_argument(
+        '--dest_port_action',
+        type=str,
+        required=False,
+        help='Destination port action (0: BLOCK, 1: ALLOW)'
+    )
+
+    parser.add_argument(
+        '--dest_port_list',
+        type=str,
+        required=False,
+        help='List of destination ports to look for'
+    )
+
+    parser.add_argument(
+        '--source_port_action',
+        type=str,
+        required=False,
+        help='Source port action (0: BLOCK, 1: ALLOW)'
+    )
+
+    parser.add_argument(
+        '--source_port_list',
+        type=str,
+        required=False,
+        help='List of source ports to look for'
+    )
+
+    parser.add_argument(
+        '--HTTP_request_action',
+        type=str,
+        required=False,
+        help='HTTP request action (0: BLOCK, 1: ALLOW)'
+    )
+
+    parser.add_argument(
+        '--HTTP_response_action',
+        type=str,
+        required=False,
+        help='HTTP response action (0: BLOCK, 1: ALLOW)'
+    )
+
+    parser.add_argument(
+        '--dns_action',
+        type=str,
+        required=False,
+        help='DNS action (0: BLOCK, 1: ALLOW)'
+    )
+
+    parser.add_argument(
+        '--dns_list',
+        type=str,
+        required=False,
+        help='List of DNS to look for'
+    )
+
+    parser.add_argument(
+        '--time_lb',
+        type=str,
+        required=False,
+        help='Time lower bound'
+    )
+
+    parser.add_argument(
+        '--time_ub',
+        type=str,
+        required=False,
+        help='Time upper bound'
+    )
+
     args = parser.parse_args()
     return args

--- a/securetea/core.py
+++ b/securetea/core.py
@@ -71,6 +71,7 @@ class SecureTea(object):
         self.telegram_provided = args_dict['telegram_provided']
         self.twilio_provided = args_dict['twilio_provided']
         self.slack_provided = args_dict['slack_provided']
+        self.firewall_provided = args_dict['firewall_provided']
 
         self.logger = logger.SecureTeaLogger(
             modulename,
@@ -122,6 +123,16 @@ class SecureTea(object):
                     logtype="error"
                 )
 
+            try:
+                if self.cred['firewall']:
+                    self.firewall_provided = True
+                    self.cred_provided = True
+            except KeyError:
+                self.logger.log(
+                    "Firewall configuraton paramter not set.",
+                    logtype="error"
+                )
+
         if not self.cred:
             self.logger.log(
                 "Configuration not found.",
@@ -136,7 +147,10 @@ class SecureTea(object):
             )
             sys.exit(0)
 
-        self.logger.log("Welcome to SecureTea..!! Initializing System")
+        self.logger.log(
+            "Welcome to SecureTea..!! Initializing System",
+            logtype="info"
+        )
 
         if self.twitter_provided:
             self.twitter = secureTeaTwitter.SecureTeaTwitter(
@@ -194,12 +208,11 @@ class SecureTea(object):
             else:
                 self.slack.notify("Welcome to SecureTea..!! Initializing System")
 
-        if args.firewall:
-            cred = credentials.get_creds(args)
+        if self.firewall_provided:
             try:
-                if cred['firewall']:
-                    firewallObj = secureTeaFirewall.SecureTeaFirewall(cred=cred,
-                                                                      debug=cred['debug'])
+                if self.cred['firewall']:
+                    firewallObj = secureTeaFirewall.SecureTeaFirewall(cred=self.cred,
+                                                                      debug=self.cred['debug'])
                     firewallObj.start_firewall()
             except KeyError:
                 self.logger.log(


### PR DESCRIPTION
## Status
**READY**

## Description
**Summary** 
1. User can configure Firewall from CLI.
2. Interactive setup-mode for Firewall.

**Changes in `@takeInput`:**
  - Recursive algorithm to iterate over nested dictionaries: Earlier, we did not have nested configuration, however SecureTea-Firewall uses a highly nested configuration, `@takeInput` can now handle all nested dictionaries. 
  - Default fall-back configuration added: If user provides an empty value for a particular input, default fall-back is used, **highly necessary for Firewall**.
  - Future developers need not to worry about complexity of setting up an interactive mode for any feature they add, `@takeInput` is highly efficient to handle most cases.

**Changes in `arguments.py`:**
  - Argument option for each firewall configuration has been added. User can configure firewall from their CLI.

**Changes in `core.py`:**
  - In order to adapt to the above changes, it's been updated accordingly.

## Related PRs
None

## Todos
- [ ] Tests
- [x] Documentation
- [x] I have fully tested the changes locally

## Deploy Notes
None

## Steps to Test or Reproduce
`sudo python3 SecureTea.py --firewall`

## Impacted Areas in Application
`args_helper.py`
`arguments.py`
`core.py`