### PR TITLE
Improve Firewall: log xnor decorator error, check root state

### DIFF
--- a/securetea/core.py
+++ b/securetea/core.py
@@ -23,6 +23,8 @@ from securetea.lib.firewall import secureTeaFirewall
 from securetea.lib.notifs import secureTeaTwilio
 from securetea.args.arguments import get_args
 from securetea.args.args_helper import ArgsHelper
+from securetea.lib.firewall.utils import setup_logger
+
 
 pynput_status = True
 
@@ -77,6 +79,9 @@ class SecureTea(object):
             modulename,
             self.cred['debug']
         )
+
+        # Setup logger for utils
+        setup_logger(debug=self.cred['debug'])
 
         if self.cred_provided:
             credentials.save_creds(self.cred)

--- a/securetea/lib/firewall/secureTeaFirewall.py
+++ b/securetea/lib/firewall/secureTeaFirewall.py
@@ -12,6 +12,8 @@ Project:
 """
 
 from securetea.lib.firewall.engine import FirewallEngine
+from securetea.lib.firewall.utils import check_root
+from securetea import logger
 
 
 class SecureTeaFirewall(object):
@@ -22,11 +24,25 @@ class SecureTeaFirewall(object):
 
         self.cred = cred['firewall']
         self.debug = cred['debug']
+        self.logger = logger.SecureTeaLogger(
+                __name__,
+                debug=self.debug
+            )
 
     def start_firewall(self):
         """
         Start firewall engine.
         """
-        engineObj = FirewallEngine(cred=self.cred,
-                                   debug=self.debug)
-        engineObj.startEngine()
+        if check_root():
+            engineObj = FirewallEngine(cred=self.cred,
+                                       debug=self.debug)
+            engineObj.startEngine()
+            self.logger.log(
+                "Firewall started",
+                logtype="info"
+            )
+        else:
+            self.logger.log(
+                "Run as root",
+                logtype="error"
+            )

--- a/securetea/lib/firewall/secureTeaFirewall.py
+++ b/securetea/lib/firewall/secureTeaFirewall.py
@@ -14,6 +14,7 @@ Project:
 from securetea.lib.firewall.engine import FirewallEngine
 from securetea.lib.firewall.utils import check_root
 from securetea import logger
+import sys
 
 
 class SecureTeaFirewall(object):
@@ -46,3 +47,4 @@ class SecureTeaFirewall(object):
                 "Run as root",
                 logtype="error"
             )
+            sys.exit(1)

--- a/securetea/lib/firewall/utils.py
+++ b/securetea/lib/firewall/utils.py
@@ -15,6 +15,33 @@ from securetea.lib.firewall.mapping import *
 import subprocess
 import re
 import os
+from securetea import logger
+
+
+# Initialize logger with debug=False
+utils_logger = logger.SecureTeaLogger(
+            __name__,
+            debug=False
+        )
+
+def setup_logger(debug):
+    """
+    Setup logger.
+
+    Args:
+        debug (bool): Debug mode or not
+
+    Raises:
+        None
+
+    Returns:
+        None
+    """
+    global utils_logger
+    utils_logger = logger.SecureTeaLogger(
+                __name__,
+                debug
+            )
 
 
 def complement(value):
@@ -83,7 +110,10 @@ def xnor(func):
                     (complement(val_dict['action']) *
                      complement(val_dict['result'])))
         except Exception as e:
-            print(e)
+            utils_logger.log(
+                "Error: " + str(e),
+                logtype="error"
+            )
             # Return allow
             return 1
     return inner_wrapper
@@ -289,5 +319,9 @@ def get_interface():
         intf = int(input('\n>> Enter the index of the interface: ')
                    .strip())
 
-    print('[!] Selected interface is : {}'.format(interfaces[intf]))
+    utils_logger.log(
+        "Selected interface is : {}".format(interfaces[intf]),
+        logtype="info"
+    )
+
     return interfaces[intf]


### PR DESCRIPTION
## Status
**READY**

## Description
1. Earlier the `@xnor` decorator errors were being printed on the terminal, this PR will ensure that the errors are logged into to the database.
2. Before starting firewall, we need to check for root privileges. If not then log it as error & exit.

## Related PRs
None

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Todos
- [ ] Tests
- [x] Documentation

## Deploy Notes
None

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
sudo SecureTea.py --firewall --debug
```

## Impacted Areas in Application
1. `securetea/lib/firewall/utils.py`
2. `@xnor`