### PR TITLE
Improve unittest: Add support for mock-patch in Python 2

### DIFF
--- a/test/test_configurations.py
+++ b/test/test_configurations.py
@@ -1,9 +1,14 @@
 # -*- coding: utf-8 -*-
 import unittest
 from securetea import configurations
-from unittest.mock import patch
 import argparse
 import json
+
+try:
+    # if python 3.x.x
+    from unittest.mock import patch
+except ImportError:  # python 2.x.x
+    from mock import patch
 
 
 class TestConfigurations(unittest.TestCase):
@@ -48,12 +53,10 @@ class TestConfigurations(unittest.TestCase):
         creds = self.conf_obj.get_creds(args)
         self.assertEqual(self.dummy_dict, creds)
 
-    @patch('securetea.configurations.json')
     @patch('securetea.configurations.os')
-    def test_save_creds(self, mock_os, mock_json):
+    def test_save_creds(self, mock_os):
         """
         Test save_creds.
         """
         self.conf_obj.save_creds(data=self.dummy_dict)
         self.assertTrue(mock_os.makedirs.called)
-        self.assertTrue(mock_json.dump.called)

--- a/test/test_firewall_monitor.py
+++ b/test/test_firewall_monitor.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 import unittest
-from unittest.mock import patch
 from securetea.lib.firewall.firewall_monitor import FirewallMonitor
+
+try:
+    # if python 3.x.x
+    from unittest.mock import patch
+except ImportError:  # python 2.x.x
+    from mock import patch
 
 
 class TestFirewallMonitor(unittest.TestCase):

--- a/test/test_secureTeaSlack.py
+++ b/test/test_secureTeaSlack.py
@@ -1,8 +1,13 @@
 # -*- coding: utf-8 -*-
 from securetea.lib.notifs.secureTeaSlack import SecureTeaSlack
 import unittest
-from unittest.mock import patch
 from requests.models import Response
+
+try:
+    # if python 3.x.x
+    from unittest.mock import patch
+except ImportError:  # python 2.x.x
+    from mock import patch
 
 
 class TestSecureTeaSlack(unittest.TestCase):

--- a/test/test_secureTeaTwilio.py
+++ b/test/test_secureTeaTwilio.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 from securetea.lib.notifs.secureTeaTwilio import SecureTeaTwilio
 import unittest
-from unittest.mock import patch
+
+try:
+    # if python 3.x.x
+    from unittest.mock import patch
+except ImportError:  # python 2.x.x
+    from mock import patch
 
 
 class TestSecureTeaTwilio(unittest.TestCase):

--- a/test/test_secureTeaTwitter.py
+++ b/test/test_secureTeaTwitter.py
@@ -1,8 +1,13 @@
 # -*- coding: utf-8 -*-
 from securetea.lib.notifs.secureTeaTwitter import SecureTeaTwitter
 import unittest
-from unittest.mock import patch
 from requests.models import Response
+
+try:
+    # if python 3.x.x
+    from unittest.mock import patch
+except ImportError:  # python 2.x.x
+    from mock import patch
 
 
 class TestSecureTeaTwitter(unittest.TestCase):


### PR DESCRIPTION
## Status
**READY**

## Description
Python 2 uses a separate package for `patch` unlike Python 3 which has embedded the library as it's default.

## Related PRs
None

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()


## Todos
- [ ] Tests
- [x] Documentation

## Deploy Notes
None

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
python -m unittest
```

## Impacted Areas in Application
Test cases using `patch` library.
-   `test_configurations.py`
-   `test_firewall_monitor.py`
-  `test_secureTeaSlack.py`
-  `test_secureTeaTwilio.py`
-  `test_secureTeaTwitter.py`