### PR TITLE
Add unittest for AWS

### DIFF
--- a/securetea/lib/notifs/aws/helper_email.py
+++ b/securetea/lib/notifs/aws/helper_email.py
@@ -38,35 +38,43 @@ class Email:
     def text(self, text):
         self._text = text
 
+    def get_details(self):
+        return {
+            "Destination": {
+                'ToAddresses': [
+                    self.to_email,
+                ],
+            },
+            "Message": {
+                'Body': {
+                    'Html': {
+                        'Charset': "UTF-8",
+                        'Data': self._html,
+                    },
+                    'Text': {
+                        'Charset': "UTF-8",
+                        'Data': self._text,
+                    },
+                },
+                'Subject': {
+                    'Charset': "UTF-8",
+                    'Data': self.subject,
+                },
+            },
+            "Source": self.from_email
+        }
+
     def send(self):
         client = boto3.client(service_name='ses',
                               region_name=self.region,
                               aws_access_key_id=self.access_key,
                               aws_secret_access_key=self.secret_key)
         try:
+            details = self.get_details()
             response = client.send_email(
-                Destination={
-                    'ToAddresses': [
-                        self.to_email,
-                    ],
-                },
-                Message={
-                    'Body': {
-                        'Html': {
-                            'Charset': "UTF-8",
-                            'Data': self._html,
-                        },
-                        'Text': {
-                            'Charset': "UTF-8",
-                            'Data': self._text,
-                        },
-                    },
-                    'Subject': {
-                        'Charset': "UTF-8",
-                        'Data': self.subject,
-                    },
-                },
-                Source=self.from_email,
+                Destination=details["Destination"],
+                Message=details["Message"],
+                Source=details["Source"],
             )
         # Display an error if something goes wrong.
         except ClientError as e:

--- a/securetea/lib/notifs/aws/secureTeaAwsSES.py
+++ b/securetea/lib/notifs/aws/secureTeaAwsSES.py
@@ -12,7 +12,7 @@ Project:
 
 """
 
-from securetea.lib.notifs.aws.helper_email import Email
+from securetea.lib.notifs.aws import helper_email
 from securetea import logger
 from securetea import common
 
@@ -44,10 +44,10 @@ class SecureTeaAwsSES():
         self.user_email = cred['aws_email']
         self.access_key = cred['aws_access_key']
         self.secret_key = cred['aws_secret_key']
-        self.email_obj = Email(self.user_email,
-                               "secureTea Security Alert!",
-                               self.access_key,
-                               self.secret_key)
+        self.email_obj = helper_email.Email(self.user_email,
+                                            "secureTea Security Alert!",
+                                            self.access_key,
+                                            self.secret_key)
 
     def notify(self, msg):
         """Docstring.
@@ -69,7 +69,7 @@ class SecureTeaAwsSES():
         typ, typ_desc = self.email_obj.send()
         if typ == "Ok":
             self.logger.log(
-                "Notification sent, message ID: "+
+                "Notification sent, message ID: " +
                 str(typ_desc)
             )
         else:

--- a/test/test_helper_email.py
+++ b/test/test_helper_email.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+from securetea.lib.notifs.aws.helper_email import Email
+import unittest
+
+try:
+    # if python 3.x.x
+    from unittest.mock import patch
+except ImportError:  # python 2.x.x
+    from mock import patch
+
+
+class TestSecureTeaHelperEmail(unittest.TestCase):
+    """
+    Test class for SecureTea AWS SES Helper Email.
+    """
+
+    def setUp(self):
+        """
+        Setup class for SecureTeaGmail.
+        """
+
+        # Setup Helper email object
+        self.email_obj = Email("random@random.com",
+                               "secureTea Security Alert!",
+                               "random-key",
+                               "random-secret")
+
+        self.email_obj.html("HTML Text")
+        self.email_obj.text("Random Text")
+
+    def test_get_details(self):
+        """
+        Test get_details.
+        """
+        details_dict = {
+            "Destination": {
+                'ToAddresses': [
+                    "random@random.com",
+                ],
+            },
+            "Message": {
+                'Body': {
+                    'Html': {
+                        'Charset': "UTF-8",
+                        'Data': "HTML Text",
+                    },
+                    'Text': {
+                        'Charset': "UTF-8",
+                        'Data': "Random Text",
+                    },
+                },
+                'Subject': {
+                    'Charset': "UTF-8",
+                    'Data': "secureTea Security Alert!",
+                },
+            },
+            "Source": "random@random.com"
+        }
+
+        self.assertEqual(details_dict,
+                         self.email_obj.get_details())
+
+    @patch('securetea.lib.notifs.aws.helper_email.boto3')
+    def test_send(self, boto3):
+        """
+        Test send.
+        """
+        boto3.client.return_value.send_email.return_value = {
+            "MessageId": "Success"
+        }
+        self.assertEqual(self.email_obj.send(),
+                        ("Ok", "Success"))
+
+    def test_html(self):
+        """
+        Test html.
+        """
+        self.email_obj.html("<html></html>")
+        self.assertEqual("<html></html>",
+                         self.email_obj._html)
+
+    def test_text(self):
+        """
+        Test text.
+        """
+        self.email_obj.text("Random")
+        self.assertEqual("Random",
+                         self.email_obj._text)

--- a/test/test_secureTeaAwsSES.py
+++ b/test/test_secureTeaAwsSES.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+from securetea.lib.notifs.aws.secureTeaAwsSES import SecureTeaAwsSES
+from securetea.lib.notifs.aws.helper_email import Email
+from securetea.logger import SecureTeaLogger
+import unittest
+
+try:
+    # if python 3.x.x
+    from unittest.mock import patch
+except ImportError:  # python 2.x.x
+    from mock import patch
+
+
+class TestSecureAWS(unittest.TestCase):
+    """
+    Test class for SecureTea AWS SES.
+    """
+
+    def setUp(self):
+        """
+        Setup class for SecureTea AWS SES.
+        """
+
+        # Initialize credentials
+        self.cred = {
+            "aws_email": "random@random.com",
+            "aws_secret_key": "random-secret",
+            "aws_access_key": "random-key",
+        }
+
+        # Setup AWS SES object
+        self.aws_obj = SecureTeaAwsSES(cred=self.cred)
+
+    @patch.object(SecureTeaLogger, 'log')
+    @patch('securetea.lib.notifs.aws.secureTeaAwsSES.common')
+    @patch.object(Email, 'html')
+    @patch.object(Email, 'send')
+    def test_notify(self,
+                    mock_helper_send,
+                    mock_helper_html,
+                    mock_common, mock_log):
+        """
+        Test notify.
+        """
+        mock_common.getdatetime.return_value = "10:00 AM"
+        mock_common.get_current_location.return_value = "Random"
+        mock_common.get_platform.return_value = "Linux"
+
+        html_str = ("<html><head></head><body><h1>Security Alert</h1><p>Random at "
+                    "10:00 AM RandomLinux</p></body></html>")
+
+        # Mock and test success of sending notification
+        mock_helper_send.return_value = ("Ok", "Success")
+        self.aws_obj.notify("Random")
+        mock_helper_html.assert_called_with(html_str)
+        msg = "Notification sent, message ID: Success"
+        mock_log.assert_called_with(msg)
+
+        # Mock and test failure of sending notification
+        mock_helper_send.return_value = ("Error", "Error")
+        self.aws_obj.notify("Random")
+        mock_helper_html.assert_called_with(html_str)
+        msg = "Aws SES notification not sent, error is: Error"
+        mock_log.assert_called_with(msg, logtype="error")


### PR DESCRIPTION
## Status
**READY**

## Description
1. A little modification in `helper_email.py` and `secureTeaAwsSes.py` to adapt to test driven code.
2. Added test cases for `helper_email.py` and `secureTeaAwsSes.py`.
3. All external API calls have been mocked.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Todos
- [x] Tests
- [x] Documentation

## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any
db migrations, etc.

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

`pytest`
`python -m unittest`

## Impacted Areas in Application
- `secureTeaAwsSes.py`
- `helper_email.py`
- `test_helper_email.py`
- `test_secureTeaAws.py`