### PR TITLE
Add R2L attack vectors to IDS

### DIFF
--- a/securetea.conf
+++ b/securetea.conf
@@ -74,7 +74,8 @@
 			"url": ""
 	},
 	"ids": {
-		"threshold": 10
+		"threshold": 10,
+		"interface": "XXXX"
 	},
 	"debug": false
 }

--- a/securetea/__init__.py
+++ b/securetea/__init__.py
@@ -18,3 +18,15 @@ from .lib.firewall import firewall_monitor
 from .lib.security_header import secureTeaHeaders
 from .lib.ids import recon_attack
 from .lib.ids import secureTeaIDS
+from .lib.ids.r2l_rules import arp_spoof
+from .lib.ids.r2l_rules import cam_attack
+from .lib.ids.r2l_rules import ddos
+from .lib.ids.r2l_rules import dhcp
+from .lib.ids.r2l_rules import land_attack
+from .lib.ids.r2l_rules import ping_of_death
+from .lib.ids.r2l_rules import r2l_engine
+from .lib.ids.r2l_rules import syn_flood
+from .lib.ids.r2l_rules.wireless import deauth
+from .lib.ids.r2l_rules.wireless import fake_access
+from .lib.ids.r2l_rules.wireless import hidden_node
+from .lib.ids.r2l_rules.wireless import ssid_spoof

--- a/securetea/args/args_helper.py
+++ b/securetea/args/args_helper.py
@@ -317,7 +317,8 @@ class ArgsHelper(object):
         default = load_default("ids")
         return {
             "input": {
-                "threshold": "threshold settings (integer value)"
+                "threshold": "threshold settings (integer value: 10 - 1000)",
+                "interface": "interface on which to monitor"
                 },
                 "default": default
         }
@@ -540,9 +541,10 @@ class ArgsHelper(object):
                 self.insecure_headers_provided = True
 
         if not self.ids_provided:
-            if (self.args.threshold):
+            if (self.args.threshold and self.args.interface):
                 ids = {}
                 ids["threshold"] = self.args.threshold
+                ids["interface"] = self.args.interface
                 self.cred["ids"] = ids
                 self.ids_provided = True
 

--- a/securetea/lib/__init__.py
+++ b/securetea/lib/__init__.py
@@ -15,3 +15,15 @@ from .firewall import firewall_monitor
 from .security_header import secureTeaHeaders
 from .ids import recon_attack
 from .ids import secureTeaIDS
+from .ids.r2l_rules import arp_spoof
+from .ids.r2l_rules import cam_attack
+from .ids.r2l_rules import ddos
+from .ids.r2l_rules import dhcp
+from .ids.r2l_rules import land_attack
+from .ids.r2l_rules import ping_of_death
+from .ids.r2l_rules import r2l_engine
+from .ids.r2l_rules import syn_flood
+from .ids.r2l_rules.wireless import deauth
+from .ids.r2l_rules.wireless import fake_access
+from .ids.r2l_rules.wireless import hidden_node
+from .ids.r2l_rules.wireless import ssid_spoof

--- a/securetea/lib/ids/__init__.py
+++ b/securetea/lib/ids/__init__.py
@@ -1,3 +1,15 @@
 """Summary."""
 from . import recon_attack
 from . import secureTeaIDS
+from .r2l_rules import arp_spoof
+from .r2l_rules import cam_attack
+from .r2l_rules import ddos
+from .r2l_rules import dhcp
+from .r2l_rules import land_attack
+from .r2l_rules import ping_of_death
+from .r2l_rules import r2l_engine
+from .r2l_rules import syn_flood
+from .r2l_rules.wireless import deauth
+from .r2l_rules.wireless import fake_access
+from .r2l_rules.wireless import hidden_node
+from .r2l_rules.wireless import ssid_spoof

--- a/securetea/lib/ids/r2l_rules/__init__.py
+++ b/securetea/lib/ids/r2l_rules/__init__.py
@@ -1,0 +1,13 @@
+"""Summary."""
+from . import arp_spoof
+from . import cam_attack
+from . import ddos
+from . import dhcp
+from . import land_attack
+from . import ping_of_death
+from . import r2l_engine
+from . import syn_flood
+from .wireless import deauth
+from .wireless import fake_access
+from .wireless import hidden_node
+from .wireless import ssid_spoof

--- a/securetea/lib/ids/r2l_rules/arp_spoof.py
+++ b/securetea/lib/ids/r2l_rules/arp_spoof.py
@@ -1,0 +1,122 @@
+u"""ARP Cache Poisoning / MiTM detection module for SecureTea IDS.
+
+Project:
+    ╔═╗┌─┐┌─┐┬ ┬┬─┐┌─┐╔╦╗┌─┐┌─┐
+    ╚═╗├┤ │  │ │├┬┘├┤  ║ ├┤ ├─┤
+    ╚═╝└─┘└─┘└─┘┴└─└─┘ ╩ └─┘┴ ┴
+    Author: Abhishek Sharma <abhishek_official@hotmail.com> , May 19 2019
+    Version: 1.1
+    Module: SecureTea
+
+"""
+
+import scapy.all as scapy
+import sys
+from io import StringIO
+import re
+from securetea import logger
+
+
+class ARPCache(object):
+    """ARP Cache poisioning / MiTM detection class."""
+
+    def __init__(self, debug=False):
+        """
+        Initialize ARPCache class.
+        Detect Man in The Middle Attack (MiTM) attacks.
+
+        Args:
+            debug (bool): Log on terminal or not
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Initialize logger
+        self.logger = logger.SecureTeaLogger(
+                __name__,
+                debug=debug
+        )
+
+    @staticmethod
+    def capture_output(to_perform):
+        """
+        Capture sys output.
+
+        Args:
+            to_perform (scapy_object)
+
+        Raises:
+            None
+
+        Returns:
+            output (str): Captured output in string format
+        """
+        capture = StringIO()
+        temp_stdout = sys.stdout
+        sys.stdout = capture
+        to_perform.show()
+        sys.stdout = temp_stdout
+        return capture.getvalue()
+
+    def get_mac(self, ip):
+        """
+        Returns MAC address of the provided IP address.
+
+        Args:
+            ip (str): IP address for which MAC address
+                      is required
+
+        Raises:
+            None
+
+        Returns:
+            mac_addr (str): MAC address of the given IP
+        """
+        arp = scapy.ARP(pdst=ip)
+        brd = scapy.Ether(dst='ff:ff:ff:ff:ff:ff')
+        arp_req_brd = brd / arp
+        answ = scapy.srp(arp_req_brd,
+                         timeout=1,
+                         verbose=False)[0]
+        mac_addr_str = self.capture_output(answ)
+        mac_addr = re.findall(r"\w\w:\w\w:\w\w:\w\w:\w\w:\w\w",
+                              mac_addr_str)[0]
+        return str(mac_addr).strip()
+
+    def proces_packet(self, pkt):
+        """
+        Process packet to detect MiTM attacks.
+
+        Args:
+            pkt (scapy_object): Scapy packet to dissect and observe
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        try:
+            if pkt.haslayer(scapy.ARP):
+                if int(pkt[scapy.ARP].op) == 2:
+                    ip = pkt[scapy.ARP].psrc
+                    real_mac = str(self.get_mac(ip))
+                    spoofed_mac = str(pkt[scapy.ARP].hwsrc)
+                    if (real_mac != spoofed_mac):
+                        self.logger.log(
+                            "ARP Cache poisioning / MiTM attack detected.",
+                            logtype="warning"
+                        )
+        except IndexError:
+            self.logger.log(
+                "Ignore error: Index",
+                logtype="info"
+            )
+        except Exception as e:
+            self.logger.log(
+                "Error occurred: " + str(e),
+                logtype="warning"
+            )

--- a/securetea/lib/ids/r2l_rules/cam_attack.py
+++ b/securetea/lib/ids/r2l_rules/cam_attack.py
@@ -1,0 +1,99 @@
+u"""CAM Attack detection module for SecureTea IDS.
+
+Project:
+    ╔═╗┌─┐┌─┐┬ ┬┬─┐┌─┐╔╦╗┌─┐┌─┐
+    ╚═╗├┤ │  │ │├┬┘├┤  ║ ├┤ ├─┤
+    ╚═╝└─┘└─┘└─┘┴└─└─┘ ╩ └─┘┴ ┴
+    Author: Abhishek Sharma <abhishek_official@hotmail.com> , May 19 2019
+    Version: 1.1
+    Module: SecureTea
+
+"""
+
+import scapy.all as scapy
+import time
+from securetea import logger
+
+
+class CAM(object):
+    """CAM Class."""
+
+    def __init__(self, debug=False):
+        """
+        Initialize CAM class.
+        Detect CAM attack.
+
+        Args:
+            debug (bool): Log on terminal or not
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Initialize logger
+        self.logger = logger.SecureTeaLogger(
+                __name__,
+                debug=debug
+        )
+        # Initialize time
+        self.start_time = None
+        # Initialize cam_attack list
+        self.cam_list = []
+        # Initialize threshold to 256 MAC address / 6 second
+        self._THRESHOLD = 256 / 6  # inter = 0.0234
+
+    def detect_cam(self, pkt):
+        """
+        Detect CAM Table attack.
+
+        Args:
+            pkt (scapy_object): Packet to observe and dissect
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        if (pkt.haslayer(scapy.Ether)):
+            source_mac = pkt[scapy.Ether].src
+
+            if self.start_time is None:
+                self.start_time = int(time.time())
+
+            if source_mac not in self.cam_list:
+                self.cam_list.append(source_mac)
+
+            self.calc_intrusion()
+
+    def calc_intrusion(self):
+        """
+        Calculate CAM attack observed ratio and
+        compare it with the set threshold to detect
+        intrusion.
+
+        Args:
+            None
+
+        Returns:
+            None
+
+        Raises:
+            None
+        """
+        total_cam = len(self.cam_list)
+        current_time = int(time.time())
+        delta_time = int(current_time - self.start_time)
+
+        try:
+            calc_threshold = int(total_cam / delta_time)
+        except ZeroDivisionError:
+            calc_threshold = int(total_cam)
+
+        if calc_threshold > self._THRESHOLD:
+            self.logger.log(
+                "Possible CAM table attack detected",
+                logtype="warning"
+            )

--- a/securetea/lib/ids/r2l_rules/ddos.py
+++ b/securetea/lib/ids/r2l_rules/ddos.py
@@ -1,0 +1,236 @@
+u"""DDoS Attack detection module for SecureTea IDS.
+
+Project:
+    ╔═╗┌─┐┌─┐┬ ┬┬─┐┌─┐╔╦╗┌─┐┌─┐
+    ╚═╗├┤ │  │ │├┬┘├┤  ║ ├┤ ├─┤
+    ╚═╝└─┘└─┘└─┘┴└─└─┘ ╩ └─┘┴ ┴
+    Author: Abhishek Sharma <abhishek_official@hotmail.com> , May 19 2019
+    Version: 1.1
+    Module: SecureTea
+
+"""
+
+import scapy.all as scapy
+import time
+from collections import OrderedDict
+from securetea import logger
+
+
+class DDoS(object):
+    """Detect DDoS attacks."""
+
+    def __init__(self, debug=False):
+        """
+        Initialize DDoS attack detection.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Initialize logger
+        self.logger = logger.SecureTeaLogger(
+                __name__,
+                debug=debug
+        )
+
+        # Initialize empty dicts
+        self.sisp = OrderedDict()
+        self.simp = OrderedDict()
+        self.misp = OrderedDict()
+        self.mimp = OrderedDict()
+
+        # Initialize threshold to 10000 packets / per second
+        self._THRESHOLD = 10000  # inter = 0.0001
+
+    def classify_ddos(self, pkt):
+        """
+        Classify DDoS attacks into the following:
+            - SISP (Single IP Single Port)
+            - SIMP (Single IP Multiple Port)
+            - MISP (Multiple IP Single Port)
+            - MIMP (Multiple IP Multiple Port)
+
+        Args:
+            pkt (scapy_object): Packet to dissect and observe
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        if (pkt.haslayer(scapy.IP) and
+            pkt.haslayer(scapy.TCP)):
+            src_ip = pkt[scapy.IP].src
+            dst_port = pkt[scapy.TCP].dport
+
+            if self.sisp.get(src_ip) is None:
+                # Packet from a new IP address
+                self.sisp[src_ip] = {
+                    "count": 1,
+                    "ports": [dst_port],
+                    "start_time": int(time.time())
+                }
+            else:
+                # Increment count
+                current_count = self.sisp[src_ip]["count"]
+                self.sisp[src_ip]["count"] = current_count + 1
+
+                if (dst_port not in \
+                    self.sisp[src_ip]["ports"]):
+                    self.sisp[src_ip]["ports"].append(dst_port)
+                    # Move to simp dict
+                    self.simp[src_ip] = self.sisp[src_ip]
+                    del self.sisp[src_ip]
+
+        # Detect intrusion
+        self.detect_sisp()
+        self.detect_simp()
+        self.detect_misp()
+        self.detect_mimp()
+
+    def detect_simp(self):
+        """
+        Detect SIMP (Single IP Multiple Port) DDoS attack.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Check intrusion for simp
+        for ip in self.simp.keys():
+            count = self.simp[ip]["count"]
+            len_port = len(self.simp[ip]["ports"])
+            start_time = int(self.simp[ip]["start_time"])
+            current_time = int(time.time())
+            delta_time = int(current_time - start_time)
+
+            try:
+                calc_count_threshold = int(count / delta_time)
+            except ZeroDivisionError:
+                calc_count_threshold = int(count)
+            try:
+                calc_portlen_threshold = int(len_port / delta_time)
+            except ZeroDivisionError:
+                calc_portlen_threshold = int(len_port)
+
+            if (calc_count_threshold > self._THRESHOLD or
+                calc_portlen_threshold > self._THRESHOLD):
+                self.logger.log(
+                    "Possible Single IP Multiple Port DDoS attack",
+                    logtype="warning"
+                )
+
+    def detect_sisp(self):
+        """
+        Detect SISP (Single IP Single Port) DDoS attack.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        for ip in self.sisp.keys():
+            count = self.sisp[ip]["count"]
+            start_time = self.sisp[ip]["start_time"]
+            current_time = int(time.time())
+            delta_time = int(current_time - start_time)
+
+            try:
+                calc_threshold = int(count / delta_time)
+            except ZeroDivisionError:
+                calc_threshold = int(count)
+
+            if (calc_threshold > self._THRESHOLD):
+                self.logger.log(
+                    "Possible Single IP Single Port DDoS attack",
+                    logtype="warning"
+                )
+
+    def detect_misp(self):
+        """
+        Detect MISP (Multiple IP Single Port) DDoS attack.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Check intrusion for misp
+        for ip in self.sisp.keys():
+            port = self.sisp[ip]["ports"][0]
+
+            if self.misp.get(port) is not None:
+                self.misp[port]["count"] = self.misp[port]["count"] + 1
+            else:
+                self.misp[port] = {
+                    "count": 1,
+                    "start_time": int(time.time())
+                }
+
+        for port in self.misp.keys():
+            count = int(self.misp[port]["count"])
+            start_time = self.misp[port]["start_time"]
+            current_time = int(time.time())
+            delta_time = int(current_time - start_time)
+
+            try:
+                calc_threshold = int(count / delta_time)
+            except ZeroDivisionError:
+                calc_threshold = int(count)
+
+            if calc_threshold > self._THRESHOLD:
+                self.logger.log(
+                    "Possible Multiple IP Single Port DDoS attack detected",
+                    logtype="warning"
+                )
+
+    def detect_mimp(self):
+        """
+        Detect SIMP (Single IP Multiple Port) DDoS attack.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        if len(self.simp) != 0:
+            start_ip = [key for key in self.simp.keys()][0]
+            end_ip = [key for key in self.simp.keys()][-1]
+
+            start_time = int(self.simp[start_ip]["start_time"])
+            end_time = int(self.simp[end_ip]["start_time"])
+            delta_time = int(end_time - start_time)
+
+            try:
+                calc_threshold = len(self.simp) / delta_time
+            except ZeroDivisionError:
+                calc_threshold = len(self.simp)
+
+            if calc_threshold > self._THRESHOLD:
+                self.logger.log(
+                    "Possible Multiple IP Multiple Port DDoS attack detected",
+                    logtype="warning"
+                )

--- a/securetea/lib/ids/r2l_rules/dhcp.py
+++ b/securetea/lib/ids/r2l_rules/dhcp.py
@@ -1,0 +1,96 @@
+u"""DHCP exhaustion attack detection module for SecureTea IDS.
+
+Project:
+    ╔═╗┌─┐┌─┐┬ ┬┬─┐┌─┐╔╦╗┌─┐┌─┐
+    ╚═╗├┤ │  │ │├┬┘├┤  ║ ├┤ ├─┤
+    ╚═╝└─┘└─┘└─┘┴└─└─┘ ╩ └─┘┴ ┴
+    Author: Abhishek Sharma <abhishek_official@hotmail.com> , May 18 2019
+    Version: 1.1
+    Module: SecureTea
+
+"""
+
+import scapy.all as scapy
+import time
+from securetea import logger
+
+
+class DHCP(object):
+    """DHCP Class."""
+
+    def __init__(self, debug=False):
+        """
+        Initialize DHCP Class.
+
+        Args:
+            debug (bool): Log on terminal or not
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Initialize logger
+        self.logger = logger.SecureTeaLogger(
+                __name__,
+                debug=debug
+        )
+
+        # Initialize required variables
+        self.start_time = None
+        self.count = 0
+
+        # Set threshold to 10 Request / per second
+        self._THRESHOLD = 10  # inter = 0.1
+
+    def detect_dhcp(self, pkt):
+        """
+        Detect DHCP exhaustion attack.
+
+        Args:
+            pkt (scapy_object): Packet to dissect and observe
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        if (pkt.haslayer(scapy.BOOTP)):
+            opcode = pkt[scapy.BOOTP].op
+
+            if int(opcode) == 1:  # Request
+                if self.start_time is None:
+                    self.start_time = time.time()
+                self.count = self.count + 1
+
+            self.calc_intrusion()
+
+    def calc_intrusion(self):
+        """
+        Calculate ratio and compare it with
+        the decided threshold to predict
+        possible intrusion.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        current_time = time.time()
+        delta_time = int(current_time - self.start_time)
+        try:
+            calc_threshold = int(self.count / delta_time)
+        except ZeroDivisionError:
+            calc_threshold = int(self.count)
+
+        if calc_threshold > self._THRESHOLD:
+            self.logger.log(
+                "Possible DHCP exhaustion attack detected.",
+                logtype="warning"
+            )

--- a/securetea/lib/ids/r2l_rules/land_attack.py
+++ b/securetea/lib/ids/r2l_rules/land_attack.py
@@ -1,0 +1,67 @@
+u"""Land attack detection module for SecureTea IDS.
+
+Project:
+    ╔═╗┌─┐┌─┐┬ ┬┬─┐┌─┐╔╦╗┌─┐┌─┐
+    ╚═╗├┤ │  │ │├┬┘├┤  ║ ├┤ ├─┤
+    ╚═╝└─┘└─┘└─┘┴└─└─┘ ╩ └─┘┴ ┴
+    Author: Abhishek Sharma <abhishek_official@hotmail.com> , May 18 2019
+    Version: 1.1
+    Module: SecureTea
+
+"""
+
+import scapy.all as scapy
+from securetea import logger
+
+
+class LandAttack(object):
+    """LandAttack class."""
+
+    def __init__(self, debug=False):
+        """
+        Initialize LandAttack class.
+
+        Args:
+            debug (bool): Log on terminal or not
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Initialize logger
+        self.logger = logger.SecureTeaLogger(
+                __name__,
+                debug=debug
+        )
+
+    def detect_land_attack(self, pkt):
+        """
+        Detect land attack by observing source,
+        destination IP & ports.
+
+        Args:
+            pkt (scapy_object): Packet to dissect and observe
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        if (pkt.haslayer(scapy.IP) and
+            pkt.haslayer(scapy.TCP)):
+
+            source_ip = pkt[scapy.IP].src
+            dest_ip = pkt[scapy.IP].dst
+
+            source_port = pkt[scapy.TCP].sport
+            dest_port = pkt[scapy.TCP].dport
+
+            if ((source_ip == dest_ip) and
+                (source_port == dest_port)):
+                self.logger.log(
+                    "Possible land attack detected.",
+                    logtype="warning"
+                )

--- a/securetea/lib/ids/r2l_rules/ping_of_death.py
+++ b/securetea/lib/ids/r2l_rules/ping_of_death.py
@@ -1,0 +1,69 @@
+u"""Ping of death attack detection module for SecureTea IDS.
+
+Project:
+    ╔═╗┌─┐┌─┐┬ ┬┬─┐┌─┐╔╦╗┌─┐┌─┐
+    ╚═╗├┤ │  │ │├┬┘├┤  ║ ├┤ ├─┤
+    ╚═╝└─┘└─┘└─┘┴└─└─┘ ╩ └─┘┴ ┴
+    Author: Abhishek Sharma <abhishek_official@hotmail.com> , May 18 2019
+    Version: 1.1
+    Module: SecureTea
+
+"""
+import scapy.all as scapy
+from securetea import logger
+
+
+class PingOfDeath(object):
+    """PingOfDeath class."""
+
+    def __init__(self, debug=False):
+        """
+        Initialize PingOfDeath.
+
+        Args:
+            debug (bool): Log on terminal or not
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Initialize logger
+        self.logger = logger.SecureTeaLogger(
+                __name__,
+                debug=debug
+        )
+
+        # Initialize threshold
+        self._THRESHOLD = 60000
+
+    def detect(self, pkt):
+        """
+        Detect ping of death attack
+        by calculating load threshold.
+
+        Args:
+            pkt (scapy_object): Packet to dissect and observe
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        if (pkt.haslayer(scapy.IP) and
+            pkt.haslayer(scapy.ICMP)):
+            # If packet has load
+            if pkt.haslayer(scapy.Raw):
+
+                load_len = len(pkt[scapy.Raw].load)
+
+                if (load_len >= self._THRESHOLD):
+                    source_ip = pkt[scapy.IP].src
+                    msg = "Possible ping of death attack detected " \
+                          "from: {}".format(source_ip)
+                    self.logger.log(
+                        msg,
+                        logtype="warning"
+                    )

--- a/securetea/lib/ids/r2l_rules/r2l_engine.py
+++ b/securetea/lib/ids/r2l_rules/r2l_engine.py
@@ -1,0 +1,83 @@
+u"""R2LEngine module for SecureTea IDS.
+
+Project:
+    ╔═╗┌─┐┌─┐┬ ┬┬─┐┌─┐╔╦╗┌─┐┌─┐
+    ╚═╗├┤ │  │ │├┬┘├┤  ║ ├┤ ├─┤
+    ╚═╝└─┘└─┘└─┘┴└─└─┘ ╩ └─┘┴ ┴
+    Author: Abhishek Sharma <abhishek_official@hotmail.com> , May 22 2019
+    Version: 1.1
+    Module: SecureTea
+
+"""
+
+from securetea.lib.ids.r2l_rules.arp_spoof import ARPCache
+from securetea.lib.ids.r2l_rules.cam_attack import CAM
+from securetea.lib.ids.r2l_rules.ddos import DDoS
+from securetea.lib.ids.r2l_rules.dhcp import DHCP
+from securetea.lib.ids.r2l_rules.ping_of_death import PingOfDeath
+from securetea.lib.ids.r2l_rules.syn_flood import SynFlood
+from securetea.lib.ids.r2l_rules.land_attack import LandAttack
+from securetea.lib.ids.r2l_rules.wireless.deauth import Deauth
+from securetea.lib.ids.r2l_rules.wireless.fake_access import FakeAccessPoint
+from securetea.lib.ids.r2l_rules.wireless.hidden_node import HiddenNode
+from securetea.lib.ids.r2l_rules.wireless.ssid_spoof import SSIDSpoof
+
+
+class R2LEngine(object):
+    """R2LEngine class."""
+
+    def __init__(self, debug=False, interface=None):
+        """
+        Initialize R2LEngine.
+
+        Args:
+            interface (str): Name of interface on which to monitor
+            debug (bool): Log on terminal or not
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Create objects of all the imported class
+        self.arp_spoof = ARPCache(debug=debug)
+        self.cam_attack = CAM(debug=debug)
+        self.dhcp = DHCP(debug=debug)
+        self.ping_of_death = PingOfDeath(debug=debug)
+        self.land_attack = LandAttack(debug=debug)
+        self.ddos = DDoS(debug=debug)
+        self.syn_flood = SynFlood(debug=debug)
+        # Wireless
+        self.deauth = Deauth(debug=debug)
+        self.fake_access = FakeAccessPoint(debug=debug)
+        self.hidden_node = HiddenNode(debug=debug)
+        self.ssid_spoof = SSIDSpoof(debug=debug, interface=interface)
+
+    def run(self, pkt):
+        """
+        Pass the packet through all the
+        filter rules.
+
+        Args:
+            pkt (scapy_object): Packet to dissect and observe
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Pass the packets
+        self.arp_spoof.proces_packet(pkt)
+        self.cam_attack.detect_cam(pkt)
+        self.dhcp.detect_dhcp(pkt)
+        self.land_attack.detect_land_attack(pkt)
+        self.ping_of_death.detect(pkt)
+        self.ddos.classify_ddos(pkt)
+        self.syn_flood.detect_syn_flood(pkt)
+        # Wireless
+        self.deauth.detect_deauth(pkt)
+        self.fake_access.detect_fake_ap(pkt)
+        self.hidden_node.detect_hidden_node(pkt)
+        self.ssid_spoof.start_process()

--- a/securetea/lib/ids/r2l_rules/syn_flood.py
+++ b/securetea/lib/ids/r2l_rules/syn_flood.py
@@ -1,0 +1,112 @@
+u"""SYN Flood attack detection module for SecureTea IDS.
+
+Project:
+    ╔═╗┌─┐┌─┐┬ ┬┬─┐┌─┐╔╦╗┌─┐┌─┐
+    ╚═╗├┤ │  │ │├┬┘├┤  ║ ├┤ ├─┤
+    ╚═╝└─┘└─┘└─┘┴└─└─┘ ╩ └─┘┴ ┴
+    Author: Abhishek Sharma <abhishek_official@hotmail.com> , May 18 2019
+    Version: 1.1
+    Module: SecureTea
+
+"""
+
+import scapy.all as scapy
+import time
+from securetea import logger
+
+
+class SynFlood(object):
+    """SynFlood Class."""
+
+    def __init__(self, debug=False):
+        """
+        Initialize SynFlood.
+
+        Args:
+            debug (bool): Log on terminal or not
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Initialize logger
+        self.logger = logger.SecureTeaLogger(
+                __name__,
+                debug=debug
+        )
+        # Initialize SYN dictionary
+        self.syn_dict = dict()
+
+        # Set threshold to 1000 SYN packets / per second
+        self._THRESHOLD = 1000  # inter = 0.001
+
+    def detect_syn_flood(self, pkt):
+        """
+        Detect SYN flood attack.
+
+        Args:
+            pkt (scapy_object): Packet to dissect and observe
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        if (pkt.haslayer(scapy.IP) and
+            pkt.haslayer(scapy.TCP)):
+            flag = pkt[scapy.TCP].flags
+            source_ip = pkt[scapy.IP].src
+
+            if flag == "S":  # SYN flag
+                if self.syn_dict.get(source_ip) is None:
+                    # If new IP address
+                    self.syn_dict[source_ip] = {
+                        "start_time": time.time(),
+                        "count": 1
+                    }
+                else:
+                    count = self.syn_dict[source_ip]["count"]
+                    self.syn_dict[source_ip]["count"] = count + 1
+            if flag == "A":  # ACK flag
+                if self.syn_dict.get(source_ip) is not None:
+                    # Handshake completed, delete the IP entry (not suspicious)
+                    del self.syn_dict[source_ip]
+
+            # Detect intrusion
+            self.calc_intrusion()
+
+    def calc_intrusion(self):
+        """
+        Detect intrusion by comparing threshold
+        ratios.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        if len(self.syn_dict) != 0:  # If syn dict is not empty
+            start_ip = [ip for ip in self.syn_dict.keys()][0]
+            start_time = self.syn_dict[start_ip]["start_time"]
+            current_time = time.time()
+            delta_time = int(current_time - start_time)
+
+            size_of_syn_dict = len(self.syn_dict)
+
+            try:
+                calc_threshold = int(size_of_syn_dict / delta_time)
+            except ZeroDivisionError:
+                calc_threshold = int(size_of_syn_dict)
+
+            if (calc_threshold >= self._THRESHOLD):
+                self.logger.log(
+                    "Possible SYN flood attack detected.",
+                    logtype="warning"
+                )

--- a/securetea/lib/ids/r2l_rules/wireless/__init__.py
+++ b/securetea/lib/ids/r2l_rules/wireless/__init__.py
@@ -1,0 +1,5 @@
+"""Summary."""
+from . import deauth
+from . import fake_access
+from . import hidden_node
+from . import ssid_spoof

--- a/securetea/lib/ids/r2l_rules/wireless/deauth.py
+++ b/securetea/lib/ids/r2l_rules/wireless/deauth.py
@@ -1,0 +1,84 @@
+u"""Wireless De-authentication attack detection module for SecureTea IDS.
+
+Project:
+    ╔═╗┌─┐┌─┐┬ ┬┬─┐┌─┐╔╦╗┌─┐┌─┐
+    ╚═╗├┤ │  │ │├┬┘├┤  ║ ├┤ ├─┤
+    ╚═╝└─┘└─┘└─┘┴└─└─┘ ╩ └─┘┴ ┴
+    Author: Abhishek Sharma <abhishek_official@hotmail.com> , May 21 2019
+    Version: 1.1
+    Module: SecureTea
+
+"""
+
+import scapy.all as scapy
+import time
+from securetea import logger
+
+
+class Deauth(object):
+    """Deauth Class."""
+
+    def __init__(self, debug=False):
+        """
+        Initialize Deauth Class.
+
+        Args:
+            debug (bool): Log on terminal or not
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Initialize logger
+        self.logger = logger.SecureTeaLogger(
+                __name__,
+                debug=debug
+        )
+
+        # Initialize time and count
+        self.start_time = None
+        self.count = 0
+
+        # Set THRESHOLD to 5 De-auth packets / per second
+        self._THRESHOLD = 5  # inter = 0.2
+
+    def detect_deauth(self, pkt):
+        """
+        Detect de-authentication attack by comparing thresholds.
+
+        Args:
+            pkt (scapy_object): Scapy packet to dissect and observe
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        if (pkt.haslayer(scapy.Dot11)):
+            if (pkt[scapy.Dot11].subtype == 0xc and
+                int(pkt[scapy.Dot11].type) == 0):
+                if (pkt[scapy.Dot11].addr1 == "ff:ff:ff:ff:ff:ff"):
+                    # Give more weightage
+                    self.count = self.count + 2
+                else:
+                    # Give less weightage
+                    self.count = self.count + 1
+                if self.start_time is None:
+                    self.start_time = time.time()
+
+        if self.start_time is not None:
+            end_time = time.time()
+            delta_time = end_time - self.start_time
+            try:
+                calc_threshold = int(self.count / delta_time)
+            except ZeroDivisionError:
+                calc_threshold = int(self.count)
+
+            if calc_threshold > self._THRESHOLD:
+                self.logger.log(
+                    "Possible de-authentication attack detected.",
+                    logtype="warning"
+                )

--- a/securetea/lib/ids/r2l_rules/wireless/fake_access.py
+++ b/securetea/lib/ids/r2l_rules/wireless/fake_access.py
@@ -1,0 +1,91 @@
+u"""Fake access point detection module for SecureTea IDS.
+
+Project:
+    ╔═╗┌─┐┌─┐┬ ┬┬─┐┌─┐╔╦╗┌─┐┌─┐
+    ╚═╗├┤ │  │ │├┬┘├┤  ║ ├┤ ├─┤
+    ╚═╝└─┘└─┘└─┘┴└─└─┘ ╩ └─┘┴ ┴
+    Author: Abhishek Sharma <abhishek_official@hotmail.com> , May 21 2019
+    Version: 1.1
+    Module: SecureTea
+
+"""
+
+import scapy.all as scapy
+from securetea import logger
+
+
+class FakeAccessPoint(object):
+    """FakeAccessPoint class."""
+
+    def __init__(self, debug=False):
+        """
+        Initialize FakeAccessPoint class.
+
+        Args:
+            debug (bool): Log on terminal or not
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Initialize logger
+        self.logger = logger.SecureTeaLogger(
+                __name__,
+                debug=debug
+        )
+
+        # Initialize access point dictionary
+        self.ap_dict = dict()
+        # Set threshold
+        self._THRESHOLD = 3
+
+    def detect_fake_ap(self, pkt):
+        """
+        Detect fake access point by observing
+        their time stamps. A genuine access point
+        broadcasts timestamp in Beacon frame for
+        clients to sync, this is in increasing
+        order always. A fake AP spoofs random
+        timestamp.
+
+        Args:
+            pkt (scapy_object): Packet to dissect and observe
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        if (pkt.haslayer(scapy.Dot11) and
+            pkt.haslayer(scapy.Dot11Beacon)):
+            if (int(pkt[scapy.Dot11].subtype) == 8):
+                # Get BSSID and timestamp
+                bssid = pkt[scapy.Dot11].addr2
+                time_stamp = pkt[scapy.Dot11Beacon].timestamp
+
+                if self.ap_dict.get(bssid) is None:
+                    # If new BSSID
+                    self.ap_dict[bssid] = {
+                        "timestamp": [time_stamp],
+                        "count": 0
+                    }
+                else:
+                    index = len(self.ap_dict[bssid]["timestamp"]) - 1
+                    last_time = self.ap_dict[bssid]["timestamp"][index]
+                    if (last_time > time_stamp):  # Time stamp not in increasing order
+                        count = self.ap_dict[bssid]["count"]
+                        self.ap_dict[bssid]["count"] = count + 1
+                    else:
+                        self.ap_dict[bssid]["timestamp"].append(time_stamp)
+
+        # Compare with threshold
+        for bssid in self.ap_dict.keys():
+            count = self.ap_dict[bssid]["count"]
+            if count > self._THRESHOLD:
+                self.logger.log(
+                    "Possible fake access point detected: {}".format(bssid),
+                    logtype="warning"
+                )

--- a/securetea/lib/ids/r2l_rules/wireless/hidden_node.py
+++ b/securetea/lib/ids/r2l_rules/wireless/hidden_node.py
@@ -1,0 +1,123 @@
+u"""Hidden node attack detection module for SecureTea IDS.
+
+Project:
+    ╔═╗┌─┐┌─┐┬ ┬┬─┐┌─┐╔╦╗┌─┐┌─┐
+    ╚═╗├┤ │  │ │├┬┘├┤  ║ ├┤ ├─┤
+    ╚═╝└─┘└─┘└─┘┴└─└─┘ ╩ └─┘┴ ┴
+    Author: Abhishek Sharma <abhishek_official@hotmail.com> , May 21 2019
+    Version: 1.1
+    Module: SecureTea
+
+"""
+
+import time
+import scapy.all as scapy
+from securetea import logger
+
+
+class HiddenNode(object):
+    """HiddenNode Class."""
+
+    def __init__(self, debug=False):
+        """
+        Initialize HiddenNode class.
+
+        Args:
+            debug (bool): Log on terminal or not
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Initialize logger
+        self.logger = logger.SecureTeaLogger(
+                __name__,
+                debug=debug
+        )
+
+        # Initialize RTS & CTS count
+        self.rts_count = 0
+        self.cts_count = 0
+
+        # Initialize RTS & CTS time
+        self.rts_start_time = None
+        self.cts_start_time = None
+
+        # Initialize threshold
+        self._THRESHOLD = 5  # inter = 0.2
+
+    def detect_hidden_node(self, pkt):
+        """
+        Count RTS & CTS packet threshold ratio to
+        detect hidden node attack. Generally, they
+        should be in an exponetial back-off scheme
+        & hence should not cross a certain threshold.
+
+        Args:
+            pkt (scapy_object): Packet to dissect and observe
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        if pkt.haslayer(scapy.Dot11):
+            subtype = int(pkt[scapy.Dot11].subtype)
+            if (subtype == 11):
+                self.rts_count = self.rts_count + 1
+                if self.rts_start_time is None:
+                    self.rts_start_time = time.time()
+            elif (subtype == 12):
+                self.cts_count = self.cts_count + 1
+                if self.cts_start_time is None:
+                    self.cts_start_time = time.time()
+
+        # Calculate intrusion thresholds
+        self.calc_intrusion()
+
+    def calc_intrusion(self):
+        """
+        Calculate threshold and compare with it
+        the pre-defined threshold to detect intrusion.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        if self.rts_start_time is not None:
+            current_time = time.time()
+            delta_time = int(current_time - self.rts_start_time)
+
+            try:
+                calc_threshold = int(self.rts_count / delta_time)
+            except ZeroDivisionError:
+                calc_threshold = int(self.rts_count)
+
+            if calc_threshold > self._THRESHOLD:
+                self.logger.log(
+                    "Possible hidden node attack detection detected.",
+                    logtype="warning"
+                )
+
+        if self.cts_start_time is not None:
+            current_time = time.time()
+            delta_time = int(current_time - self.cts_start_time)
+
+            try:
+                calc_threshold = int(self.cts_count / delta_time)
+            except ZeroDivisionError:
+                calc_threshold = int(self.cts_count)
+
+            if calc_threshold > self._THRESHOLD:
+                self.logger.log(
+                    "Possible hidden node attack detection detected.",
+                    logtype="warning"
+                )

--- a/securetea/lib/ids/r2l_rules/wireless/ssid_spoof.py
+++ b/securetea/lib/ids/r2l_rules/wireless/ssid_spoof.py
@@ -1,0 +1,121 @@
+u"""SSID spoofing (Evil Twin Attack) detection module for SecureTea IDS.
+
+Project:
+    ╔═╗┌─┐┌─┐┬ ┬┬─┐┌─┐╔╦╗┌─┐┌─┐
+    ╚═╗├┤ │  │ │├┬┘├┤  ║ ├┤ ├─┤
+    ╚═╝└─┘└─┘└─┘┴└─└─┘ ╩ └─┘┴ ┴
+    Author: Abhishek Sharma <abhishek_official@hotmail.com> , May 21 2019
+    Version: 1.1
+    Module: SecureTea
+
+"""
+
+import subprocess
+import re
+from securetea import logger
+
+
+class SSIDSpoof(object):
+    """SSIDSpoof Class."""
+
+    def __init__(self,
+                 interface=None,
+                 debug=False):
+        """
+        Initialize SSIDSpoof class.
+
+        Args:
+            interface (str): Name of the interface to monitor
+            debug (bool): Log on terminal or not
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Initialize logger
+        self.logger = logger.SecureTeaLogger(
+                __name__,
+                debug=debug
+        )
+
+        self.interface = interface
+        self.scan_dict = dict()
+
+    def update_list(self):
+        """
+        Monitor the nearby WiFi hotspots and
+        update the dictionary.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        command = "iwlist {} scanning | egrep 'Cell | ESSID'".format(self.interface)
+
+        try:
+            for _ in range(5):
+                output = subprocess.check_output(command,
+                                                 shell=True)
+                output = output.decode('utf-8')
+
+                found = re.findall("Address:(.*)\n.*ESSID:(.*)",
+                                   output)
+                self.detect_spoof(found)
+        except Exception as e:
+            self.logger.log(
+                "Error occurred: " + str(e),
+                logtype="error"
+            )
+
+    def detect_spoof(self, found):
+        """
+        Detect SSID spoofing by comparing BSSID of
+        same SSIDs.
+
+        Args:
+            found (list): List of BSSID & ESSIDs
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        for tup in found:
+            bssid = tup[0]
+            essid = tup[1].strip('"')
+
+            if self.scan_dict.get(essid) is None:
+                # If new ESSID is found
+                self.scan_dict[essid] = bssid
+            else:
+                previous_bssid = self.scan_dict[essid]
+                if previous_bssid != bssid:
+                    self.logger.log(
+                        "Possible SSID spoofing attack detected: {}".format(essid),
+                        logtype="warning"
+                    )
+
+    def start_process(self):
+        """
+        Start the SSID spoof detection process.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        if (self.interface is not None and
+            self.interface != "XXXX"):
+            self.update_list()

--- a/securetea/lib/ids/secureTeaIDS.py
+++ b/securetea/lib/ids/secureTeaIDS.py
@@ -12,6 +12,7 @@ Project:
 """
 
 from securetea.lib.ids.recon_attack import DetectRecon
+from securetea.lib.ids.r2l_rules.r2l_engine import R2LEngine
 from securetea.lib.firewall.utils import check_root
 from securetea import logger
 import scapy.all as scapy
@@ -47,6 +48,8 @@ class SecureTeaIDS(object):
             # Create DetectRecon object
             self.recon_obj = DetectRecon(threshold=self.cred["threshold"],
                                          debug=debug)
+            # Create R2LEngine object
+            self.r2l_rules = R2LEngine(debug=debug, interface=self.cred["interface"])
             self.logger.log(
                 "SecureTea Intrusion Detection started",
                 logtype="info"
@@ -64,7 +67,7 @@ class SecureTeaIDS(object):
         filters.
 
         - Reconnaissance attacks
-        - R2L attacks (to be added)
+        - R2L attacks
 
         Args:
             scapy_pkt (scapy_object): Packet to dissect and process
@@ -77,6 +80,8 @@ class SecureTeaIDS(object):
         """
         # Process the packet for reconnaissance detection
         self.recon_obj.run(scapy_pkt)
+        # Process the packet for R2L attack detection
+        self.r2l_rules.run(scapy_pkt)
 
     def start_ids(self):
         """

--- a/test/test_arp_spoof.py
+++ b/test/test_arp_spoof.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+import unittest
+from securetea.lib.ids.r2l_rules.arp_spoof import ARPCache
+import scapy.all as scapy
+from securetea.logger import SecureTeaLogger
+
+try:
+    # if python 3.x.x
+    from unittest.mock import patch
+except ImportError:  # python 2.x.x
+    from mock import patch
+
+
+class TestARPCache(unittest.TestCase):
+    """
+    Test class for SecureTea IDS ARP Spoof Attack Detection.
+    """
+
+    def setUp(self):
+        """
+        Setup class for ARPCache.
+        """
+        # Initialize ARPCache object
+        self.arp_spoof = ARPCache()
+        self.pkt1 = scapy.ARP(op=2)
+
+    @patch("securetea.lib.ids.r2l_rules.arp_spoof.scapy")
+    @patch.object(ARPCache, "capture_output")
+    def test_get_mac(self, mock_capture, scapy_mock):
+        """
+        Test get_mac.
+        """
+        scapy_mock.srp.return_value = "Random answer"
+        mock_capture.return_value = "ff:ff:ff:ff:ff:ff"
+        mac = self.arp_spoof.get_mac("192.168.0.1")
+        self.assertEqual(mac, "ff:ff:ff:ff:ff:ff")
+
+    @patch.object(SecureTeaLogger, 'log')
+    @patch.object(ARPCache, "get_mac")
+    def test_process_packet(self, mock_get_mac, mock_log):
+        """
+        Test proces_packet.
+        """
+        # Case 1: When real_mac == spoofed_mac
+        mock_get_mac.return_value = "ff:ff:ff:ff:ff:ff"
+        pkt1 = scapy.ARP(op=2,
+                         psrc="192.168.0.1",
+                         hwsrc="ff:ff:ff:ff:ff:ff")
+        self.arp_spoof.proces_packet(pkt1)
+        self.assertFalse(mock_log.called)
+
+        # Case 2: When real mac != spoofed_mac
+        mock_get_mac.return_value = "aa:aa:aa:aa:aa:aa"
+        pkt1 = scapy.ARP(op=2,
+                         psrc="192.168.0.1",
+                         hwsrc="ff:ff:ff:ff:ff:ff")
+        self.arp_spoof.proces_packet(pkt1)
+        mock_log.assert_called_with("ARP Cache poisioning / MiTM attack detected.",
+                                    logtype="warning")

--- a/test/test_cam_attack.py
+++ b/test/test_cam_attack.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+import unittest
+from securetea.lib.ids.r2l_rules.cam_attack import CAM
+import scapy.all as scapy
+from securetea.logger import SecureTeaLogger
+
+try:
+    # if python 3.x.x
+    from unittest.mock import patch
+except ImportError:  # python 2.x.x
+    from mock import patch
+
+
+class TestCAM(unittest.TestCase):
+    """
+    Test class for SecureTea IDS CAM Flood Attack Detection.
+    """
+
+    def setUp(self):
+        """
+        Setup class for CAM.
+        """
+        self.pkt1 = scapy.Ether(src="ff:ff:ff:ff:ff:ff")
+
+        # Initialize CAM object
+        self.cam = CAM()
+
+    @patch.object(SecureTeaLogger, 'log')
+    def test_detect_cam(self, mock_log):
+        """
+        Test detect_cam.
+        """
+        # Pass a Ether frame packet
+        # it should be added to the list
+        self.cam.detect_cam(self.pkt1)
+        self.assertEqual(self.cam.cam_list,
+                         ["ff:ff:ff:ff:ff:ff"])
+
+    @patch.object(SecureTeaLogger, 'log')
+    @patch("securetea.lib.ids.r2l_rules.cam_attack.time.time")
+    def test_calc_intrusion(self, mock_time, mock_log):
+        """
+        Test calc_intrusion.
+        """
+        # delta_time = 1
+        mock_time.return_value = 11
+        self.cam.start_time = 10
+
+        # Case 1: Threshold within the limit range
+        self.cam.calc_intrusion()
+        self.assertFalse(mock_log.called)
+
+        # Case 2: Replicate attack
+        for _ in range(50):
+            self.cam.cam_list.append(scapy.RandMAC())
+
+        self.cam.calc_intrusion()
+        mock_log.assert_called_with("Possible CAM table attack detected",
+                                    logtype="warning")

--- a/test/test_ddos.py
+++ b/test/test_ddos.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+import unittest
+from securetea.lib.ids.r2l_rules.ddos import DDoS
+import scapy.all as scapy
+from securetea.logger import SecureTeaLogger
+
+try:
+    # if python 3.x.x
+    from unittest.mock import patch
+except ImportError:  # python 2.x.x
+    from mock import patch
+
+
+class TestDDoS(unittest.TestCase):
+    """
+    Test class for SecureTea IDS DDoS Attack Detection.
+    """
+
+    def setUp(self):
+        """
+        Setup class for TestDDoS.
+        """
+        # Initialize DDoS object
+        self.ddos = DDoS()
+        self.pkt1 = scapy.ARP(op=2)
+
+    @patch("securetea.lib.ids.r2l_rules.ddos.time.time")
+    def test_classify_ddos(self, mock_time):
+        """
+        Test classify_ddos.
+        """
+        # Case 1: Classify as SISP
+        mock_time.return_value = 10
+        pkt = scapy.IP(src="192.168.0.1") \
+              / scapy.TCP(dport=80)
+        self.ddos.classify_ddos(pkt)
+        l = len(self.ddos.sisp)
+        self.assertEqual(l, 1)
+        temp_dict = {
+            "count": 1,
+            "ports": [80],
+            "start_time": 10
+        }
+        self.assertTrue(self.ddos.sisp.get("192.168.0.1"))
+        self.assertEqual(temp_dict,
+                         self.ddos.sisp["192.168.0.1"])
+        # Check if count increments by 1
+        self.ddos.classify_ddos(pkt)
+        self.assertEqual(self.ddos.sisp["192.168.0.1"]["count"], 2)
+
+        # Case2: Classify as SIMP
+        pkt = scapy.IP(src="192.168.0.1") \
+              / scapy.TCP(dport=90)
+        self.ddos.classify_ddos(pkt)
+        # IP entry should get deleted from SISP dict
+        l = len(self.ddos.sisp)
+        self.assertEqual(l, 0)
+
+        l2 = len(self.ddos.simp)
+        self.assertEqual(l2, 1)
+        temp_dict = {
+            "count": 3,
+            "ports": [80, 90],
+            "start_time": 10
+        }
+        self.assertTrue(self.ddos.simp.get("192.168.0.1"))
+        self.assertEqual(self.ddos.simp["192.168.0.1"],
+                        temp_dict)
+
+    @patch.object(SecureTeaLogger, 'log')
+    @patch("securetea.lib.ids.r2l_rules.ddos.time.time")
+    def test_detect_misp(self, mock_time, mock_log):
+        """
+        Test detect_misp.
+        """
+        mock_time.return_value = 10
+
+        # Create packets with different IP
+        # but with same ports
+        self.ddos.sisp["127.0.0.1"] = {
+            "count": 1,
+            "ports": [80],
+            "start_time": 10
+        }
+        self.ddos.sisp["127.0.0.2"] = {
+            "count": 1,
+            "ports": [80],
+            "start_time": 10
+        }
+        self.ddos.detect_misp()
+
+        # Check if MISP dict got updated
+        temp_dict = {
+            "count": 2,
+            "start_time": 10
+        }
+
+        self.assertTrue(self.ddos.misp.get(80))
+        self.assertEqual(self.ddos.misp[80], temp_dict)
+        self.assertFalse(mock_log.called)
+
+        # Replicate attack by increasing
+        # the count beyond threshold
+        self.ddos.misp[80]["count"] = 20000
+        self.ddos.detect_misp()
+        mock_log.assert_called_with("Possible Multiple IP Single Port DDoS attack detected",
+                                    logtype="warning")
+
+    @patch("securetea.lib.ids.r2l_rules.ddos.time.time")
+    @patch.object(SecureTeaLogger, 'log')
+    def test_detect_sisp(self, mock_log, mock_time):
+        """
+        Test detect_sisp.
+        """
+        # Case 1: Within the threshold
+        self.ddos.sisp["192.168.0.1"] = {
+            "count": 1,
+            "start_time": 10,
+            "ports": [80]
+        }
+        self.assertFalse(mock_log.called)
+
+        # Case 2: Replicate attack by increasing
+        # the count beyond threshold
+        self.ddos.sisp["192.168.0.1"] = {
+            "count": 20000,
+            "start_time": 10,
+            "ports": [80]
+        }
+        mock_time.return_value = 11
+        self.ddos.detect_sisp()
+        mock_log.assert_called_with("Possible Single IP Single Port DDoS attack",
+                                    logtype="warning")
+
+    @patch("securetea.lib.ids.r2l_rules.ddos.time.time")
+    @patch.object(SecureTeaLogger, 'log')
+    def test_detect_simp(self, mock_log, mock_time):
+        """
+        Test detect_simp.
+        """
+        # Case 1: Threshold within the range
+        self.ddos.simp["192.168.0.1"] = {
+            "count": 1,
+            "start_time": 10,
+            "ports": [80, 90]
+        }
+        mock_time.return_value = 11
+        self.ddos.detect_simp()
+        self.assertFalse(mock_log.called)
+
+        # Case 2: Threshold beyond the range
+        self.ddos.simp["192.168.0.1"] = {
+            "count": 20000,
+            "ports": [80, 90],
+            "start_time": 10
+        }
+        self.ddos.detect_simp()
+        mock_log.assert_called_with("Possible Single IP Multiple Port DDoS attack",
+                                    logtype="warning")
+
+    @patch.object(SecureTeaLogger, 'log')
+    def test_detect_mimp(self, mock_log):
+        """
+        Test detect_mimp.
+        """
+        # Replicate attack
+        for _ in range(20000):
+            ip = str(scapy.RandIP())
+            self.ddos.simp[ip] = {
+                "count": 1,
+                "start_time": 10,
+                "ports": [80, 90]
+            }
+
+        self.ddos.detect_mimp()
+        mock_log.assert_called_with("Possible Multiple IP Multiple Port DDoS attack detected",
+                                    logtype="warning")

--- a/test/test_deauth.py
+++ b/test/test_deauth.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+import unittest
+from securetea.lib.ids.r2l_rules.wireless.deauth import Deauth
+import scapy.all as scapy
+from securetea.logger import SecureTeaLogger
+
+try:
+    # if python 3.x.x
+    from unittest.mock import patch
+except ImportError:  # python 2.x.x
+    from mock import patch
+
+
+class TestDeauth(unittest.TestCase):
+    """
+    Test class for SecureTea IDS Deauth Attack Detection.
+    """
+
+    def setUp(self):
+        """
+        Setup class for Deauth.
+        """
+        # Packets replicating attack
+        self.pkt1 = scapy.Dot11(subtype=12,
+                                type=0,
+                                addr1="ff:ff:ff:ff:ff:ff")
+        self.pkt2 = scapy.Dot11(subtype=12,
+                                type=0,
+                                addr1="aa:aa:aa:aa:aa:aa")
+
+        # Initialize Deauth object
+        self.deauth = Deauth()
+
+    @patch("securetea.lib.ids.r2l_rules.wireless.deauth.time.time")
+    @patch.object(SecureTeaLogger, 'log')
+    def test_detect_deauth(self, mock_log, mock_time):
+        """
+        Test detect_deauth.
+        """
+        # Case 1: Count should increment by 2
+        self.deauth.detect_deauth(self.pkt1)
+        self.assertEqual(self.deauth.count, 2)
+
+        # Case 2: Count should increment by 1
+        self.deauth.detect_deauth(self.pkt2)
+        self.assertEqual(self.deauth.count, 3)
+
+        # delta_time = 1
+        self.deauth.start_time = 10
+        mock_time.return_value = 11
+
+        # Case 1: Threshold within the limit
+        self.deauth.detect_deauth(self.pkt1)
+        self.assertFalse(mock_log.called)
+
+        # Case2: Threshold outside the limit (attack)
+        self.deauth.count = 10
+        self.deauth.detect_deauth(self.pkt1)
+        mock_log.assert_called_with("Possible de-authentication attack detected.",
+                                    logtype="warning")

--- a/test/test_dhcp.py
+++ b/test/test_dhcp.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+import unittest
+from securetea.lib.ids.r2l_rules.dhcp import DHCP
+import scapy.all as scapy
+from securetea.logger import SecureTeaLogger
+
+try:
+    # if python 3.x.x
+    from unittest.mock import patch
+except ImportError:  # python 2.x.x
+    from mock import patch
+
+
+class TestDHCP(unittest.TestCase):
+    """
+    Test class for SecureTea IDS DHCP Exhaustion Attack Detection.
+    """
+
+    def setUp(self):
+        """
+        Setup class for TestDHCP.
+        """
+        # Create a request packet
+        self.pkt1 = scapy.BOOTP(op=1)
+
+        # Create a response packet
+        self.pkt2 = scapy.BOOTP(op=2)
+
+        # Initialize DHCP object
+        self.dhcp = DHCP()
+
+    @patch.object(SecureTeaLogger, 'log')
+    def test_detect_dhcp(self, mock_log):
+        """
+        Test detect_dhcp.
+        """
+        # Case 1: Valid request packet
+        # count should increment by 1
+        self.dhcp.detect_dhcp(self.pkt1)
+        self.assertEqual(self.dhcp.count, 1)
+
+        # Case 2: Not a valid request packet
+        # count should stay the same
+        self.dhcp.detect_dhcp(self.pkt2)
+        self.assertEqual(self.dhcp.count, 1)
+
+    @patch.object(SecureTeaLogger, 'log')
+    @patch("securetea.lib.ids.r2l_rules.dhcp.time.time")
+    def test_calc_intrusion(self, mock_time, mock_log):
+        """
+        Test calc_intrusion.
+        """
+        mock_time.return_value = 11
+        self.dhcp.start_time = 10
+
+        # Case 1: Threshold within limits
+        self.dhcp.count = 1
+        self.dhcp.calc_intrusion()
+        self.assertFalse(mock_log.called)
+
+        # Case 2: Threshold out of limit (attack)
+        self.dhcp.count = 20
+        self.dhcp.calc_intrusion()
+        mock_log.assert_called_with("Possible DHCP exhaustion attack detected.",
+                                    logtype="warning")

--- a/test/test_fake_access.py
+++ b/test/test_fake_access.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+import unittest
+from securetea.lib.ids.r2l_rules.wireless.fake_access import FakeAccessPoint
+import scapy.all as scapy
+from securetea.logger import SecureTeaLogger
+
+try:
+    # if python 3.x.x
+    from unittest.mock import patch
+except ImportError:  # python 2.x.x
+    from mock import patch
+
+
+class TestFakeAccessPoint(unittest.TestCase):
+    """
+    Test class for SecureTea IDS FakeAccessPoint Attack Detection.
+    """
+
+    def setUp(self):
+        """
+        Setup class for FakeAccessPoint.
+        """
+        # Create attack replicating packets
+        self.pkt1 = scapy.Dot11(subtype=8,
+                                addr2="aa:bb:cc:dd:ee:ff") \
+                    / scapy.Dot11Beacon(timestamp=10)
+
+        self.pkt2 = scapy.Dot11(subtype=8,
+                                addr2="aa:bb:cc:dd:ee:ff") \
+                    / scapy.Dot11Beacon(timestamp=9)
+
+        # Initialize FakeAccessPoint object
+        self.fake_ap = FakeAccessPoint()
+
+    @patch.object(SecureTeaLogger, 'log')
+    def test_detect_fake_ap(self, mock_log):
+        """
+        Test detect_fake_ap.
+        """
+        # Check if the packet having Dot11 & Dot11Beacon
+        # gets added to the dict
+        self.fake_ap.detect_fake_ap(self.pkt1)
+        temp_dict = {
+            "timestamp": [10],
+            "count": 0
+        }
+        self.assertTrue(self.fake_ap.ap_dict.get("aa:bb:cc:dd:ee:ff"))
+        self.assertEqual(self.fake_ap.ap_dict["aa:bb:cc:dd:ee:ff"],
+                        temp_dict)
+
+        # Another packet passed with same BSSID, timestamp is less
+        # than the previous, this should increment count
+        self.fake_ap.detect_fake_ap(self.pkt2)
+        self.assertEqual(self.fake_ap.ap_dict["aa:bb:cc:dd:ee:ff"]["count"],
+                         1)
+        self.assertFalse(mock_log.called)
+
+        # Repeat the attack, so that count crosses
+        # the threshold & attack is detected
+        for _ in range(5):
+            self.fake_ap.detect_fake_ap(self.pkt2)
+
+        mock_log.assert_called_with("Possible fake access point detected: aa:bb:cc:dd:ee:ff",
+                                    logtype="warning")

--- a/test/test_hidden_node.py
+++ b/test/test_hidden_node.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+import unittest
+from securetea.lib.ids.r2l_rules.wireless.hidden_node import HiddenNode
+import scapy.all as scapy
+from securetea.logger import SecureTeaLogger
+
+try:
+    # if python 3.x.x
+    from unittest.mock import patch
+except ImportError:  # python 2.x.x
+    from mock import patch
+
+
+class TestHiddenNode(unittest.TestCase):
+    """
+    Test class for SecureTea IDS HiddenNode Attack Detection.
+    """
+
+    def setUp(self):
+        """
+        Setup class for HiddenNode.
+        """
+        # Packets replicating attacks
+        self.pkt1 = scapy.Dot11(subtype=11)
+        self.pkt2 = scapy.Dot11(subtype=12)
+
+        # Initialize HiddenNode object
+        self.hidden_node = HiddenNode()
+
+    def test_hidden_node(self):
+        """
+        Test hidden_node.
+        """
+        # Case 1: RTS count increment by one
+        self.hidden_node.detect_hidden_node(self.pkt1)
+        self.assertEqual(self.hidden_node.rts_count, 1)
+
+        # Case 2: CTS count increment by one
+        self.hidden_node.detect_hidden_node(self.pkt2)
+        self.assertEqual(self.hidden_node.cts_count, 1)
+
+    @patch("securetea.lib.ids.r2l_rules.wireless.hidden_node.time.time")
+    @patch.object(SecureTeaLogger, 'log')
+    def test_calc_intrusion(self, mock_log, mock_time):
+        """
+        Test calc_intrusion.
+        """
+        # delta_time = 1
+        mock_time.return_value = 11
+        self.hidden_node.rts_start_time = 10
+        self.hidden_node.cts_start_time = 10
+
+        # When threshold is within the range
+        self.hidden_node.calc_intrusion()
+        self.assertFalse(mock_log.called)
+
+        # Replicate attack count
+        self.hidden_node.rts_count = 20
+        self.hidden_node.cts_count = 20
+        self.hidden_node.calc_intrusion()
+        mock_log.assert_called_with("Possible hidden node attack detection detected.",
+                                    logtype="warning")

--- a/test/test_land_attack.py
+++ b/test/test_land_attack.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+import unittest
+from securetea.lib.ids.r2l_rules.land_attack import LandAttack
+import scapy.all as scapy
+from securetea.logger import SecureTeaLogger
+
+try:
+    # if python 3.x.x
+    from unittest.mock import patch
+except ImportError:  # python 2.x.x
+    from mock import patch
+
+
+class TestLandAttack(unittest.TestCase):
+    """
+    Test class for SecureTea IDS Land Attack Detection.
+    """
+
+    def setUp(self):
+        """
+        Setup class for LandAttack.
+        """
+        # Create scapy packet (valid attack)
+        self.pkt = scapy.IP(src="192.168.0.1",
+                            dst="192.168.0.1") \
+                   / scapy.TCP(sport=80, dport=80)
+
+        # Create a scapy packet (invalid attack)
+        self.pkt2 = scapy.IP(src="192.168.0.1",
+                            dst="192.168.0.6") \
+                    / scapy.TCP(sport=80, dport=90)
+
+        # Create LandAttack object
+        self.land_attack_obj = LandAttack()
+
+    @patch.object(SecureTeaLogger, 'log')
+    def test_detect_land_attack(self, mock_log):
+        """
+        Test detect_land_attack.
+        """
+        # Case 1: When condition for land attack is invalid
+        self.land_attack_obj.detect_land_attack(self.pkt2)
+        self.assertFalse(mock_log.called)
+
+        # Case 2: When condition for land attack is valid
+        self.land_attack_obj.detect_land_attack(self.pkt)
+        mock_log.assert_called_with("Possible land attack detected.",
+                                    logtype="warning")

--- a/test/test_ping_of_death.py
+++ b/test/test_ping_of_death.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+import unittest
+from securetea.lib.ids.r2l_rules.ping_of_death import PingOfDeath
+import scapy.all as scapy
+from securetea.logger import SecureTeaLogger
+
+try:
+    # if python 3.x.x
+    from unittest.mock import patch
+except ImportError:  # python 2.x.x
+    from mock import patch
+
+
+class TestPingOfDeath(unittest.TestCase):
+    """
+    Test class for SecureTea IDS PingOfDeath Attack Detection.
+    """
+
+    def setUp(self):
+        """
+        Setup class for PingOfDeath.
+        """
+        # Packet with load < 60000
+        self.pkt1 = scapy.IP(src="192.168.0.1") \
+                    / scapy.ICMP() / scapy.Raw(load="*")
+
+        # Packet with load > 60000 (attack)
+        self.pkt2 = scapy.IP(src="192.168.0.1") \
+                   / scapy.ICMP() / scapy.Raw(load="*" * 65535)
+
+        # Initialize PingOfDeath object
+        self.ping_of_death = PingOfDeath()
+
+    @patch.object(SecureTeaLogger, 'log')
+    def test_detect(self, mock_log):
+        """
+        Test detect_ping_of_death.
+        """
+        # Case 1: Non suspicious packet
+        self.ping_of_death.detect(self.pkt1)
+        self.assertFalse(mock_log.called)
+
+        # Case 2: Suspicious packet
+        self.ping_of_death.detect(self.pkt2)
+        msg = "Possible ping of death attack detected " \
+               "from: 192.168.0.1"
+        mock_log.assert_called_with(msg,
+                                    logtype="warning")

--- a/test/test_ssid_spoof.py
+++ b/test/test_ssid_spoof.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+import unittest
+from securetea.lib.ids.r2l_rules.wireless.ssid_spoof import SSIDSpoof
+from securetea.logger import SecureTeaLogger
+
+try:
+    # if python 3.x.x
+    from unittest.mock import patch
+except ImportError:  # python 2.x.x
+    from mock import patch
+
+
+class TestSSIDSpoof(unittest.TestCase):
+    """
+    Test class for SecureTea IDS SSID Spoof Attack Detection.
+    """
+
+    def setUp(self):
+        """
+        Setup class for SSIDSpoof.
+        """
+        # Initialize SSIDSpoof
+        self.ssid_spoof = SSIDSpoof()
+
+    @patch.object(SecureTeaLogger, 'log')
+    def test_detect_spoof(self, mock_log):
+        """
+        Test detect_spoof.
+        """
+        # Create a list of tuple
+        temp_list = [("aa:bb:cc:dd:ee:ff", "Name")]
+        self.ssid_spoof.detect_spoof(temp_list)
+        self.assertFalse(mock_log.called)
+
+        # Same name but different BSSID
+        temp_list = [("aa:bb:cc:dd:ff:ee", "Name")]
+        self.ssid_spoof.detect_spoof(temp_list)
+        mock_log.assert_called_with("Possible SSID spoofing attack detected: Name",
+                                    logtype="warning")

--- a/test/test_syn_flood.py
+++ b/test/test_syn_flood.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+import unittest
+from securetea.lib.ids.r2l_rules.syn_flood import SynFlood
+import scapy.all as scapy
+from securetea.logger import SecureTeaLogger
+
+try:
+    # if python 3.x.x
+    from unittest.mock import patch
+except ImportError:  # python 2.x.x
+    from mock import patch
+
+
+class TestSynFlood(unittest.TestCase):
+    """
+    Test class for SecureTea IDS SYN Flood Attack Detection.
+    """
+
+    def setUp(self):
+        """
+        Setup class for SynFlood.
+        """
+        # Packet with SYN flag
+        self.pkt1 = scapy.IP(src="192.168.0.1") \
+                    / scapy.TCP(flags="S")
+
+        # Packet with ACK flag (handshake completed)
+        self.pkt2 = scapy.IP(src="192.168.0.1") \
+                    / scapy.TCP(flags="A")
+
+        # Create SynFlood object
+        self.syn_flood = SynFlood()
+
+    @patch("securetea.lib.ids.r2l_rules.syn_flood.time.time")
+    def test_detect_syn_flood(self, mock_time):
+        """
+        Test detect_syn_flood.
+        """
+        mock_time.return_value = 10
+
+        # Pass SYN packet, it should be added to dict
+        self.syn_flood.detect_syn_flood(self.pkt1)
+        self.assertTrue(self.syn_flood.syn_dict.get("192.168.0.1"))
+        temp_dict = {
+            "start_time": 10,
+            "count": 1
+        }
+        self.assertEqual(self.syn_flood.syn_dict["192.168.0.1"],
+                         temp_dict)
+
+        # Pass ACK packet, IP entry should be removed now
+        # as handshake is completed, hence not suspicious
+        self.syn_flood.detect_syn_flood(self.pkt2)
+        self.assertFalse(self.syn_flood.syn_dict.get("192.168.0.1"))
+
+    @patch("securetea.lib.ids.r2l_rules.syn_flood.time.time")
+    @patch.object(SecureTeaLogger, 'log')
+    def test_calc_intrusion(self, mock_log, mock_time):
+        """
+        Test calc_intrusion.
+        """
+        mock_time.return_value = 11
+
+        # Replicate a non attack SYN packet flow
+        for _ in range(10):
+            self.syn_flood.syn_dict[str(scapy.RandIP())] = {
+                "start_time": 10,
+                "count": 1
+            }
+        self.syn_flood.calc_intrusion()
+        self.assertFalse(mock_log.called)
+
+        # Replicate a SYN Flood attack
+        for _ in range(2000):
+            self.syn_flood.syn_dict[str(scapy.RandIP())] = {
+                "start_time": 10,
+                "count": 1
+            }
+        self.syn_flood.calc_intrusion()
+        mock_log.assert_called_with("Possible SYN flood attack detected.",
+                                    logtype="warning")


### PR DESCRIPTION
## Status
**READY**

## Description
**Detect Denial of Service (DoS) & Remote to Local (R2L) attacks**
- DoS attacks
- CAM Table Exhaustion
- DHCP Exhaustion
- Man in The Middle (MiTM) / ARP cache poisoning
- SYN flood attack
- Ping of death
- Land attack
- Wireless
     - Deauthentication attack
    - Hidden node attack
    - SSID spoofing
    - Fake access point
## Related PRs
None

## Todos
- [x] Tests
- [x] Documentation
- [x] Well tested locally
- [x] Master branch up to date
- [x] Python 2 & 3 support
- [x] Attack vectors are completely modularized

## Deploy Notes
None

## Steps to Test or Reproduce
`python3 SecureTea.py --ids --debug`

## Impacted Areas in Application
SecureTea Intrusion Detection System (IDS)

## Sample Demo
ARP Cache poisoning / MiTM attack using ettercap.
- **Attack replication setup:**
   - 2 Kali Linux VMs connected to each other in a NAT network.
   - Default gateway IP: 10.0.2.1
![ARP_MIiTM](https://user-images.githubusercontent.com/29058921/58319305-48ba9800-7e37-11e9-8ab3-e01d86a63bd9.gif)

## Development Environment
```
Host machine OS: Ubuntu 18.04 LTS
Virtual machine OS: Kali Linux 2018.2
Python : 3.6.5 & 2.7
Editor: Sublime Text 3
```
## More Details
Here the critical details I did not mention in my GSoC proposal, in order to keep it short and intact.

- DDoS attacks - It can be further divided into 4 types:
    - Single IP Single Port (SISP)
    - Single IP Multiple Port (SIMP)
    - Multiple IP Single Port (MISP)
    - Multiple IP Multiple Port (MIMP)
I have ensured that IDS detects first classify attack into these and detect a possible DoS attack accordingly.

- SYN Flood - To eliminate false positives, I have ensured that IDS monitors every single connection i.e. it keeps on checking whether the handshakes are completed or not. A certain amount of incomplete handshakes within a certain amount of time will trigger an attack alarm.

- SSID spoofing - I could have used airmon-ng to put the interface in monitor mode, but this would have kicked out of the internet connectivity, thus failing to monitor network! Also, this would have increased dependency. Hence, I'm using subprocess module and Linux commands to monitor nearby SSIDs and get their BSSIDs. Possibly, Codacy would not allow a subprocess module, so please have a look @rejahrehim @adeyosemanputra.

- Fake Access point - I'm using the timestamp of the Beacon Frame. These are broadcasted by the APs to help the client sync, a fake AP will broadcast a random timestamp. Also, the time-stamps are in increasing order, hence any abnormality will trigger an attack alarm.

- The rest attack vectors are as per the flowchart in the proposal. They have been modified slightly to reduce false-positives.