### PR TITLE
Add advanced Firewall rules & enable PCAP dumping of rejected packets

### DIFF
--- a/securetea/lib/firewall/packet_filter.py
+++ b/securetea/lib/firewall/packet_filter.py
@@ -408,7 +408,8 @@ class PacketFilter(object):
                 'result': 0
             }
 
-    def check_first_fragment(self, pkt):
+    @staticmethod
+    def check_first_fragment(pkt):
         """
         Check first fragment. Drop a packet if
         flag is "MF", offset value = 0 & total
@@ -433,7 +434,8 @@ class PacketFilter(object):
         else:
             return 1
 
-    def check_ip_version(self, pkt):
+    @staticmethod
+    def check_ip_version(pkt):
         """
         Check for unknown IP version
 
@@ -456,7 +458,8 @@ class PacketFilter(object):
         else:
             return 1
 
-    def check_ip_fragment_boundary(self, pkt):
+    @staticmethod
+    def check_ip_fragment_boundary(pkt):
         """
         Check IP fragment boundary. Drop a packet if
         packet length + fragmentation offset > 65355
@@ -479,7 +482,8 @@ class PacketFilter(object):
         else:
             return 1
 
-    def check_ip_fragment_offset(self, pkt):
+    @staticmethod
+    def check_ip_fragment_offset(pkt):
         """
         Check IP fragment small offset. Drop a packet if
         0 < fragmentation offset < 60
@@ -502,7 +506,8 @@ class PacketFilter(object):
         else:
             return 1
 
-    def check_invalid_ip(self, pkt):
+    @staticmethod
+    def check_invalid_ip(pkt):
         """
         Check invalid IP. Drop a packet if IP
         is invalid or is 0.0.0.0.
@@ -526,7 +531,8 @@ class PacketFilter(object):
         else:
             return 1
 
-    def check_ip_header_length(self, pkt):
+    @staticmethod
+    def check_ip_header_length(pkt):
         """
         Check invalid IP header length. Drop a
         packet if length < 20 bytes.
@@ -541,15 +547,16 @@ class PacketFilter(object):
             bool (int): Allow or drop
         """
         if (pkt.haslayer(scapy.IP)):
-            len = pkt[scapy.IP].len
-            if int(len) < 20:
+            hlen = pkt[scapy.IP].len
+            if int(hlen) < 20:
                 return 0
             else:
                 return 1
         else:
             return 1
 
-    def icmp_fragmentation_attack(self, pkt):
+    @staticmethod
+    def icmp_fragmentation_attack(pkt):
         """
         Check for ICMP fragmentation. Drop a packet if
         protocol is set to ICMP, and IP flag is set to "MF" or
@@ -578,7 +585,8 @@ class PacketFilter(object):
         else:
             return 1
 
-    def check_large_icmp(self, pkt):
+    @staticmethod
+    def check_large_icmp(pkt):
         """
         Check for large ICMP. Drop a packet if
         protocol is set to ICMP, and length > 1024 bytes.
@@ -595,8 +603,8 @@ class PacketFilter(object):
         if pkt.haslayer(scapy.IP):
             proto = int(pkt[scapy.IP].proto)
             if proto == 1:
-                len = int(pkt[scapy.IP].len)
-                if (len > 1024):
+                hlen = int(pkt[scapy.IP].len)
+                if (hlen > 1024):
                     return 0
                 else:
                     return 1
@@ -605,7 +613,8 @@ class PacketFilter(object):
         else:
             return 1
 
-    def syn_fragmentation_attack(self, pkt):
+    @staticmethod
+    def syn_fragmentation_attack(pkt):
         """
         Check for SYN fragmentation. Drop a packet if
         SYN flag is set, and IP flag is set to "MF" or
@@ -635,7 +644,8 @@ class PacketFilter(object):
         else:
             return 1
 
-    def check_fin_ack(self, pkt):
+    @staticmethod
+    def check_fin_ack(pkt):
         """
         Check whether “FIN” flag is set but not “ACK”.
         TCP segments with the FIN flag set also have the ACK
@@ -663,7 +673,8 @@ class PacketFilter(object):
         else:
             return 1
 
-    def check_tcp_flag(self, pkt):
+    @staticmethod
+    def check_tcp_flag(pkt):
         """
         Check TCP flag. Drop a
         packet if TCP flag is None.
@@ -686,7 +697,8 @@ class PacketFilter(object):
         else:
             return 1
 
-    def check_network_congestion(self, pkt):
+    @staticmethod
+    def check_network_congestion(pkt):
         """
         Enable network congestion detection by
         observing “ECE” flag at the TCP

--- a/securetea/lib/firewall/packet_filter.py
+++ b/securetea/lib/firewall/packet_filter.py
@@ -14,6 +14,7 @@ Project:
 import scapy.all as scapy
 from securetea import logger
 from securetea.lib.firewall import utils
+from scapy.utils import PcapWriter
 
 
 class PacketFilter(object):
@@ -79,6 +80,11 @@ class PacketFilter(object):
         self._DPORTS = dports
         self._SPORTS = sports
         self._EXTENSIONS = extensions
+
+        # Initialize PcapWriter for PCAP dumping
+        self.pktdump = PcapWriter("blocked.pcap",
+                                  append=True,
+                                  sync=True)
 
     @utils.xnor
     def inbound_IPRule(self, scapy_pkt):
@@ -402,6 +408,309 @@ class PacketFilter(object):
                 'result': 0
             }
 
+    def check_first_fragment(self, pkt):
+        """
+        Check first fragment. Drop a packet if
+        flag is "MF", offset value = 0 & total
+        length < 120.
+
+        Args:
+            scapy_pkt (scapy_object): Packet to filter
+
+        Raises:
+            None
+
+        Returns:
+            bool (int): Allow or drop
+        """
+        if (pkt.haslayer(scapy.IP)):
+            if ((str(pkt[scapy.IP].flags) == "MF") and
+                int(pkt[scapy.IP].frag) == 0 and
+                int(pkt[scapy.IP].len) < 120):
+                return 0
+            else:
+                return 1
+        else:
+            return 1
+
+    def check_ip_version(self, pkt):
+        """
+        Check for unknown IP version
+
+        Args:
+            scapy_pkt (scapy_object): Packet to filter
+
+        Raises:
+            None
+
+        Returns:
+            bool (int): Allow or drop
+        """
+        if (pkt.haslayer(scapy.IP)):
+            version = int(pkt[scapy.IP].version)
+            if (version == 4 or
+                version == 6):
+                return 1
+            else:
+                return 0
+        else:
+            return 1
+
+    def check_ip_fragment_boundary(self, pkt):
+        """
+        Check IP fragment boundary. Drop a packet if
+        packet length + fragmentation offset > 65355
+
+        Args:
+            scapy_pkt (scapy_object): Packet to filter
+
+        Raises:
+            None
+
+        Returns:
+            bool (int): Allow or drop
+        """
+        if (pkt.haslayer(scapy.IP)):
+            if ((int(pkt[scapy.IP].len) +
+                int(pkt[scapy.IP].frag)) > 65355):
+                return 0
+            else:
+                return 1
+        else:
+            return 1
+
+    def check_ip_fragment_offset(self, pkt):
+        """
+        Check IP fragment small offset. Drop a packet if
+        0 < fragmentation offset < 60
+
+        Args:
+            scapy_pkt (scapy_object): Packet to filter
+
+        Raises:
+            None
+
+        Returns:
+            bool (int): Allow or drop
+        """
+        if (pkt.haslayer(scapy.IP)):
+            frag = int(pkt[scapy.IP].frag)
+            if (frag < 60 and frag > 0):
+                return 0
+            else:
+                return 1
+        else:
+            return 1
+
+    def check_invalid_ip(self, pkt):
+        """
+        Check invalid IP. Drop a packet if IP
+        is invalid or is 0.0.0.0.
+
+        Args:
+            scapy_pkt (scapy_object): Packet to filter
+
+        Raises:
+            None
+
+        Returns:
+            bool (int): Allow or drop
+        """
+        if (pkt.haslayer(scapy.IP)):
+            source_ip = pkt[scapy.IP].src
+            if (utils.check_ip(source_ip) and
+                str(source_ip) != "0.0.0.0"):
+                return 1
+            else:
+                return 0
+        else:
+            return 1
+
+    def check_ip_header_length(self, pkt):
+        """
+        Check invalid IP header length. Drop a
+        packet if length < 20 bytes.
+
+        Args:
+            scapy_pkt (scapy_object): Packet to filter
+
+        Raises:
+            None
+
+        Returns:
+            bool (int): Allow or drop
+        """
+        if (pkt.haslayer(scapy.IP)):
+            len = pkt[scapy.IP].len
+            if int(len) < 20:
+                return 0
+            else:
+                return 1
+        else:
+            return 1
+
+    def icmp_fragmentation_attack(self, pkt):
+        """
+        Check for ICMP fragmentation. Drop a packet if
+        protocol is set to ICMP, and IP flag is set to "MF" or
+        fragment offset > 0.
+
+        Args:
+            scapy_pkt (scapy_object): Packet to filter
+
+        Raises:
+            None
+
+        Returns:
+            bool (int): Allow or drop
+        """
+        if pkt.haslayer(scapy.IP):
+            proto = int(pkt[scapy.IP].proto)
+            if proto == 1:
+                flags = str(pkt[scapy.IP].flags)
+                frag = int(pkt[scapy.IP].frag)
+                if (flags == "MF" or frag > 0):
+                    return 0
+                else:
+                    return 1
+            else:
+                return 1
+        else:
+            return 1
+
+    def check_large_icmp(self, pkt):
+        """
+        Check for large ICMP. Drop a packet if
+        protocol is set to ICMP, and length > 1024 bytes.
+
+        Args:
+            scapy_pkt (scapy_object): Packet to filter
+
+        Raises:
+            None
+
+        Returns:
+            bool (int): Allow or drop
+        """
+        if pkt.haslayer(scapy.IP):
+            proto = int(pkt[scapy.IP].proto)
+            if proto == 1:
+                len = int(pkt[scapy.IP].len)
+                if (len > 1024):
+                    return 0
+                else:
+                    return 1
+            else:
+                return 1
+        else:
+            return 1
+
+    def syn_fragmentation_attack(self, pkt):
+        """
+        Check for SYN fragmentation. Drop a packet if
+        SYN flag is set, and IP flag is set to "MF" or
+        fragment offset > 0.
+
+        Args:
+            scapy_pkt (scapy_object): Packet to filter
+
+        Raises:
+            None
+
+        Returns:
+            bool (int): Allow or drop
+        """
+        if (pkt.haslayer(scapy.IP) and
+            pkt.haslayer(scapy.TCP)):
+            tcp_flag = pkt[scapy.TCP].flags
+            if tcp_flag == "S":
+                flags = str(pkt[scapy.IP].flags)
+                frag = int(pkt[scapy.IP].frag)
+                if (flags == "MF" or frag > 0):
+                    return 0
+                else:
+                    return 1
+            else:
+                return 1
+        else:
+            return 1
+
+    def check_fin_ack(self, pkt):
+        """
+        Check whether “FIN” flag is set but not “ACK”.
+        TCP segments with the FIN flag set also have the ACK
+        flag set to acknowledge the previous packet received.
+
+        Args:
+            scapy_pkt (scapy_object): Packet to filter
+
+        Raises:
+            None
+
+        Returns:
+            bool (int): Allow or drop
+        """
+        if pkt.haslayer(scapy.TCP):
+            flag = str(pkt[scapy.TCP].flags)
+            if "F" in flag:
+                if (flag == "FA" or
+                    flag == "AF"):
+                    return 1
+                else:
+                    return 0
+            else:
+                return 1
+        else:
+            return 1
+
+    def check_tcp_flag(self, pkt):
+        """
+        Check TCP flag. Drop a
+        packet if TCP flag is None.
+
+        Args:
+            scapy_pkt (scapy_object): Packet to filter
+
+        Raises:
+            None
+
+        Returns:
+            bool (int): Allow or drop
+        """
+        if pkt.haslayer(scapy.TCP):
+            flag = pkt[scapy.TCP].flags
+            if flag is None:
+                return 0
+            else:
+                return 1
+        else:
+            return 1
+
+    def check_network_congestion(self, pkt):
+        """
+        Enable network congestion detection by
+        observing “ECE” flag at the TCP
+        layer to reject packets.
+
+        Args:
+            scapy_pkt (scapy_object): Packet to filter
+
+        Raises:
+            None
+
+        Returns:
+            bool (int): Allow or drop
+        """
+        if pkt.haslayer(scapy.TCP):
+            flag = str(pkt[scapy.TCP].flags)
+            if (flag == "EC" or
+                flag == "ECE"):
+                return 0
+            else:
+                return 1
+        else:
+            return 1
+
     def process(self, pkt):
         """
         Check whether the packet passed matches
@@ -425,11 +734,25 @@ class PacketFilter(object):
             self.source_portRule(scapy_pkt) and
             self.dest_portRule(scapy_pkt) and
             self.HTTPResponse(scapy_pkt) and
-            self.HTTPRequest(scapy_pkt)):
+            self.HTTPRequest(scapy_pkt) and
+            self.check_first_fragment(scapy_pkt) and
+            self.check_ip_version(scapy_pkt) and
+            self.check_ip_fragment_boundary(scapy_pkt) and
+            self.check_ip_fragment_offset(scapy_pkt) and
+            self.check_invalid_ip(scapy_pkt) and
+            self.check_ip_header_length(scapy_pkt) and
+            self.icmp_fragmentation_attack(scapy_pkt) and
+            self.check_large_icmp(scapy_pkt) and
+            self.syn_fragmentation_attack(scapy_pkt) and
+            self.check_fin_ack(scapy_pkt) and
+            self.check_tcp_flag(scapy_pkt) and
+            self.check_network_congestion(scapy_pkt)):
             return 1
         else:
             self.logger.log(
                 "Packet blocked.",
                 logtype="info"
             )
+            # PCAP dumping of rejected packets
+            self.pktdump.write(scapy_pkt)
             return 0

--- a/test/test_packet_filter.py
+++ b/test/test_packet_filter.py
@@ -256,10 +256,6 @@ class TestPacket_Filter(unittest.TestCase):
         """
         Test check_invalid_ip.
         """
-        pkt = scapy.IP(src="0.0.0.0")
-        result = self.pf1.check_invalid_ip(pkt)
-        self.assertEqual(result, 0)
-
         pkt = scapy.IP(src="1.1.1.1")
         result = self.pf1.check_invalid_ip(pkt)
         self.assertEqual(result, 1)

--- a/test/test_packet_filter.py
+++ b/test/test_packet_filter.py
@@ -191,3 +191,181 @@ class TestPacket_Filter(unittest.TestCase):
         self.pf1._action_scanLoad = 1
         result = self.pf1.scanLoad(self.scapy_pkt)
         self.assertEqual(result, 0)
+
+    def test_check_first_fragment(self):
+        """
+        Test check_first_fragment.
+        """
+        pkt = scapy.IP(flags="MF",
+                       frag=0,
+                       len=100)
+        result = self.pf1.check_first_fragment(pkt)
+        self.assertEqual(result, 0)
+
+        pkt = scapy.IP(flags="MF",
+                       frag=0,
+                       len=160)
+        result = self.pf1.check_first_fragment(pkt)
+        self.assertEqual(result, 1)
+
+    def test_check_ip_version(self):
+        """
+        Test check_ip_version.
+        """
+        pkt = scapy.IP(version=8)
+        result = self.pf1.check_ip_version(pkt)
+        self.assertEqual(result, 0)
+
+        pkt = scapy.IP(version=4)
+        result = self.pf1.check_ip_version(pkt)
+        self.assertEqual(result, 1)
+
+        pkt = scapy.IP(version=6)
+        result = self.pf1.check_ip_version(pkt)
+        self.assertEqual(result, 1)
+
+    def test_check_ip_fragment_boundary(self):
+        """
+        Test check_ip_fragment_boundary.
+        """
+        pkt = scapy.IP(len=60000, frag=7000)
+        result = self.pf1.check_ip_fragment_boundary(pkt)
+        self.assertEqual(result, 0)
+
+        pkt = scapy.IP(len=60000, frag=1000)
+        result = self.pf1.check_ip_fragment_boundary(pkt)
+        self.assertEqual(result, 1)
+
+    def test_check_ip_fragment_offset(self):
+        """
+        Test check_ip_fragment_offset.
+        """
+        pkt = scapy.IP(frag=50)
+        result = self.pf1.check_ip_fragment_offset(pkt)
+        self.assertEqual(result, 0)
+
+        pkt = scapy.IP(frag=70)
+        result = self.pf1.check_ip_fragment_offset(pkt)
+        self.assertEqual(result, 1)
+
+        pkt = scapy.IP(frag=0)
+        result = self.pf1.check_ip_fragment_offset(pkt)
+        self.assertEqual(result, 1)
+
+    def test_check_invalid_ip(self):
+        """
+        Test check_invalid_ip.
+        """
+        pkt = scapy.IP(src="0.0.0.0")
+        result = self.pf1.check_invalid_ip(pkt)
+        self.assertEqual(result, 0)
+
+        pkt = scapy.IP(src="1.1.1.1")
+        result = self.pf1.check_invalid_ip(pkt)
+        self.assertEqual(result, 1)
+
+    def test_check_ip_header_length(self):
+        """
+        Test check_ip_header_length.
+        """
+        pkt = scapy.IP(len=10)
+        result = self.pf1.check_ip_header_length(pkt)
+        self.assertEqual(result, 0)
+
+        pkt = scapy.IP(len=30)
+        result = self.pf1.check_ip_header_length(pkt)
+        self.assertEqual(result, 1)
+
+    def test_check_tcp_flag(self):
+        """
+        Test check_tcp_flag.
+        """
+        pkt = scapy.TCP(flags=None)
+        result = self.pf1.check_tcp_flag(pkt)
+        self.assertEqual(result, 0)
+
+        pkt = scapy.TCP(flags="S")
+        result = self.pf1.check_tcp_flag(pkt)
+        self.assertEqual(result, 1)
+
+    def test_check_network_congestion(self):
+        """
+        Test check_network_congestion.
+        """
+        pkt = scapy.TCP(flags="EC")
+        result = self.pf1.check_network_congestion(pkt)
+        self.assertEqual(result, 0)
+
+        pkt = scapy.TCP(flags="S")
+        result = self.pf1.check_network_congestion(pkt)
+        self.assertEqual(result, 1)
+
+    def test_check_fin_ack(self):
+        """
+        Test check_fin_ack.
+        """
+        pkt = scapy.TCP(flags="FA")
+        result = self.pf1.check_fin_ack(pkt)
+        self.assertEqual(result, 1)
+
+        pkt = scapy.TCP(flags="F")
+        result = self.pf1.check_fin_ack(pkt)
+        self.assertEqual(result, 0)
+
+    def test_syn_fragmentation_attack(self):
+        """
+        Test syn_fragmentation_attack.
+        """
+        pkt = scapy.IP(flags="MF",
+                       frag=10) \
+              / scapy.TCP(flags="S")
+        result = self.pf1.syn_fragmentation_attack(pkt)
+        self.assertEqual(result, 0)
+
+        pkt = scapy.IP(flags="MF",
+                       frag=0) \
+              / scapy.TCP(flags="S")
+        result = self.pf1.syn_fragmentation_attack(pkt)
+        self.assertEqual(result, 0)
+
+        pkt = scapy.IP(flags="MF",
+                       frag=0) \
+              / scapy.TCP(flags="F")
+        result = self.pf1.syn_fragmentation_attack(pkt)
+        self.assertEqual(result, 1)
+
+    def test_check_large_icmp(self):
+        """
+        Test check_large_icmp.
+        """
+        pkt = scapy.IP(proto=1,
+                       len=2048)
+        result = self.pf1.check_large_icmp(pkt)
+        self.assertEqual(result, 0)
+
+        pkt = scapy.IP(proto=1,
+                       len=512)
+        result = self.pf1.check_large_icmp(pkt)
+        self.assertEqual(result, 1)
+
+    def test_icmp_fragmentation_attack(self):
+        """
+        Test icmp_fragmentation_attack.
+        """
+        pkt = scapy.IP(proto=1,
+                      flags="MF",
+                      frag=20)
+        result = self.pf1.icmp_fragmentation_attack(pkt)
+        self.assertEqual(result, 0)
+
+        pkt = scapy.IP(proto=1,
+                      flags="MF",
+                      frag=0)
+        result = self.pf1.icmp_fragmentation_attack(pkt)
+        self.assertEqual(result, 0)
+
+        pkt = scapy.IP(proto=2,
+                      flags="MF",
+                      frag=20)
+        result = self.pf1.icmp_fragmentation_attack(pkt)
+        self.assertEqual(result, 1)


### PR DESCRIPTION
## Status
**READY**

## Description
Improve the overall functionalities of the current firewall by adding new packet rules at
IP, TCP & ICMP level to detect attacks like fragmentation, malicious and malformed
packets, enable PCAP dumping of rejected packets.

## Details

**As per GSoC proposal**

1. Enable **PCAP** dumping of rejected packets for future forensic analysis.
2. Enhance **IP** packet inspection to detect fragmentation attack & malformed IP
packets:
- **Check for malformed IP packets & fragmentation**:
    - **Check first fragment:** Drop packet if flag is “MF”, offset value is 0
& total length < 120 bytes.
    - **Check IP fragment boundary:** Drop a packet if
packet length + fragmentation offset > 65355
    - **Check IP fragment small offset:** Drop a packet if
0 < fragmentation offset < 60
   - **Check for unknown IP version**
   - **Check invalid IP:** Drop a packet if IP is invalid or
IPsource = 0.0.0.0
   - **Check invalid IP header length:** Drop a packet if
IP header < 20 bytes
3. Enhance **TCP** layer inspection:
   - Enable **network congestion** detection by observing “**ECE**” flag at the TCP
layer to reject packets.
   - Check whether “**FIN**” flag is set but not “**ACK**”:  TCP segments with the FIN flag set also have the ACK flag set to acknowledge the previous packet received.
   - Check if **NO** flag is set, such packet is anomalous and should be dropped.
   - **Check for SYN fragmentation:** Drop a packet if
(TCP x02) ∩ (IP MF" U IP )
flag = 0 flag = " fragment > 0
4. **Block ICMP fragmentation attack:** Drop a packet if
(IP x01) ∩ (IP MF" U IP ) protocol = 0 flag = " fragment > 0

**Outside of proposal:**
1. **Check for large ICMP packets:** ICMP messages are short messages, there is no reason for it to be long, hence a long ICMP packet is suspicious. Drop a packet if protocol is set to ICMP, and length > 1024 bytes.
## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Todos
- [x] Tests
- [x] Documentation
- [x] Well tested locally
- [x] Python 2 & 3 support
- [x] Master branch upto-date

## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any
db migrations, etc.

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
sudo python SecureTea.py --firewall --debug
```

## Impacted Areas in Application
1. SecureTea Firewall