### PR TITLE
Mock get_current_location API call

### DIFF
--- a/test/test_secureTeaSlack.py
+++ b/test/test_secureTeaSlack.py
@@ -37,12 +37,14 @@ class TestSecureTeaSlack(unittest.TestCase):
         self.slack_obj = SecureTeaSlack(cred=self.cred,
                                         debug=self.debug)
 
+    @patch('securetea.lib.notifs.secureTeaSlack.common.get_current_location')
     @patch('securetea.lib.notifs.secureTeaSlack.logger')
     @patch('securetea.lib.notifs.secureTeaSlack.requests')
-    def test_notify(self, mock_requests, mock_log):
+    def test_notify(self, mock_requests, mock_log, mock_loc):
         """
         Test notify.
         """
+        mock_loc.return_value = "Random location"
         mock_requests.post.return_value = self.response
 
         # If response['ok'] is valid

--- a/test/test_secureTeaTwitter.py
+++ b/test/test_secureTeaTwitter.py
@@ -59,12 +59,14 @@ class TestSecureTeaTwitter(unittest.TestCase):
         with self.assertRaises(KeyError):
             self.twitter_obj.getuserid()
 
+    @patch('securetea.lib.notifs.secureTeaTwitter.common.get_current_location')
     @patch('securetea.lib.notifs.secureTeaTwitter.logger')
     @patch('securetea.lib.notifs.secureTeaTwitter.requests')
-    def test_notify(self, mock_requests, mock_log):
+    def test_notify(self, mock_requests, mock_log, mock_loc):
         """
         Test notify.
         """
+        mock_loc.return_value = "Random location"
         # Setup twitter object
         mock_requests.get.return_value = self.response
         self.twitter_obj = SecureTeaTwitter(debug=self.debug,


### PR DESCRIPTION
## Status
**READY**

## Description
Method: `get_current_location()` method was not being
mocked in test cases, thus calling the external
API always.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Todos
- [x] Tests
- [x] Documentation

## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any
db migrations, etc.

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git pull --prune
git checkout <feature-branch>
```
## Impacted Areas in Application
List general components of the application that this PR will affect: