### PR TITLE
Add system log monitor

### DIFF
--- a/securetea/__init__.py
+++ b/securetea/__init__.py
@@ -30,3 +30,14 @@ from .lib.ids.r2l_rules.wireless import deauth
 from .lib.ids.r2l_rules.wireless import fake_access
 from .lib.ids.r2l_rules.wireless import hidden_node
 from .lib.ids.r2l_rules.wireless import ssid_spoof
+from .lib.log_monitor.system_log import check_sync
+from .lib.log_monitor.system_log import detect_backdoor
+from .lib.log_monitor.system_log import detect_sniffer
+from .lib.log_monitor.system_log import engine
+from .lib.log_monitor.system_log import failed_login
+from .lib.log_monitor.system_log import harmful_root_command
+from .lib.log_monitor.system_log import non_std_hash
+from .lib.log_monitor.system_log import password_defect
+from .lib.log_monitor.system_log import port_scan
+from .lib.log_monitor.system_log import ssh_login
+from .lib.log_monitor.system_log import utils

--- a/securetea/__init__.py
+++ b/securetea/__init__.py
@@ -33,11 +33,9 @@ from .lib.ids.r2l_rules.wireless import ssid_spoof
 from .lib.log_monitor.system_log import check_sync
 from .lib.log_monitor.system_log import detect_backdoor
 from .lib.log_monitor.system_log import detect_sniffer
-from .lib.log_monitor.system_log import engine
 from .lib.log_monitor.system_log import failed_login
 from .lib.log_monitor.system_log import harmful_root_command
 from .lib.log_monitor.system_log import non_std_hash
 from .lib.log_monitor.system_log import password_defect
 from .lib.log_monitor.system_log import port_scan
 from .lib.log_monitor.system_log import ssh_login
-from .lib.log_monitor.system_log import utils

--- a/securetea/args/args_helper.py
+++ b/securetea/args/args_helper.py
@@ -153,6 +153,7 @@ class ArgsHelper(object):
         self.firewall_provided = False
         self.insecure_headers_provided = False
         self.ids_provided = False
+        self.system_log_provided = False
 
         # Setup logger
         self.logger = logger.SecureTeaLogger(
@@ -459,6 +460,9 @@ class ArgsHelper(object):
                 self.cred["ids"] = ids
                 self.ids_provided = True
 
+        if self.args.system_log and not self.system_log_provided:
+            self.system_log_provided = True
+
         if (self.args.insecure_headers and
             not self.insecure_headers_provided and
             not self.args.url):
@@ -624,7 +628,8 @@ class ArgsHelper(object):
             self.firewall_provided or
             self.insecure_headers_provided or
             self.gmail_provided or
-            self.ids_provided):
+            self.ids_provided or
+            self.system_log_provided):
             self.cred_provided = True
 
         return {
@@ -638,5 +643,6 @@ class ArgsHelper(object):
             'gmail_provided': self.gmail_provided,
             'firewall_provided': self.firewall_provided,
             'insecure_headers_provided': self.insecure_headers_provided,
-            'ids_provided': self.ids_provided
+            'ids_provided': self.ids_provided,
+            'system_log_provided': self.system_log_provided
         }

--- a/securetea/args/arguments.py
+++ b/securetea/args/arguments.py
@@ -390,5 +390,13 @@ def get_args():
         help="Intrusion Detection System (IDS) threshold"
     )
 
+    parser.add_argument(
+        '--system_log',
+        '-sys_log',
+        action="store_true",
+        required=False,
+        help="Start system log monitoring process"
+    )
+
     args = parser.parse_args()
     return args

--- a/securetea/core.py
+++ b/securetea/core.py
@@ -30,6 +30,7 @@ from securetea.args.args_helper import ArgsHelper
 from securetea.lib.firewall.utils import setup_logger
 from securetea.lib.security_header import secureTeaHeaders
 from securetea.lib.ids import secureTeaIDS
+from securetea.lib.log_monitor.system_log import engine
 
 pynput_status = True
 
@@ -79,6 +80,7 @@ class SecureTea(object):
         self.firewall_provided = args_dict['firewall_provided']
         self.insecure_headers_provided = args_dict['insecure_headers_provided']
         self.ids_provided = args_dict['ids_provided']
+        self.system_log_provided = args_dict['system_log_provided']
 
         # Initialize logger
         self.logger = logger.SecureTeaLogger(
@@ -321,6 +323,16 @@ class SecureTea(object):
             except KeyError:
                 self.logger.log(
                     "Intrusion Detection System (IDS) parameter not configured.",
+                    logtype="error"
+                )
+
+        if self.system_log_provided:
+            try:
+                sys_obj = engine.SystemLogEngine(debug=self.cred['debug'])
+                sys_obj.run()
+            except Exception as e:
+                self.logger.log(
+                    "Error occured: " + str(e),
                     logtype="error"
                 )
 

--- a/securetea/lib/__init__.py
+++ b/securetea/lib/__init__.py
@@ -30,11 +30,9 @@ from .ids.r2l_rules.wireless import ssid_spoof
 from .log_monitor.system_log import check_sync
 from .log_monitor.system_log import detect_backdoor
 from .log_monitor.system_log import detect_sniffer
-from .log_monitor.system_log import engine
 from .log_monitor.system_log import failed_login
 from .log_monitor.system_log import harmful_root_command
 from .log_monitor.system_log import non_std_hash
 from .log_monitor.system_log import password_defect
 from .log_monitor.system_log import port_scan
 from .log_monitor.system_log import ssh_login
-from .log_monitor.system_log import utils

--- a/securetea/lib/__init__.py
+++ b/securetea/lib/__init__.py
@@ -27,3 +27,14 @@ from .ids.r2l_rules.wireless import deauth
 from .ids.r2l_rules.wireless import fake_access
 from .ids.r2l_rules.wireless import hidden_node
 from .ids.r2l_rules.wireless import ssid_spoof
+from .log_monitor.system_log import check_sync
+from .log_monitor.system_log import detect_backdoor
+from .log_monitor.system_log import detect_sniffer
+from .log_monitor.system_log import engine
+from .log_monitor.system_log import failed_login
+from .log_monitor.system_log import harmful_root_command
+from .log_monitor.system_log import non_std_hash
+from .log_monitor.system_log import password_defect
+from .log_monitor.system_log import port_scan
+from .log_monitor.system_log import ssh_login
+from .log_monitor.system_log import utils

--- a/securetea/lib/log_monitor/__init__.py
+++ b/securetea/lib/log_monitor/__init__.py
@@ -1,0 +1,12 @@
+"""Summary."""
+from .system_log import check_sync
+from .system_log import detect_backdoor
+from .system_log import detect_sniffer
+from .system_log import engine
+from .system_log import failed_login
+from .system_log import harmful_root_command
+from .system_log import non_std_hash
+from .system_log import password_defect
+from .system_log import port_scan
+from .system_log import ssh_login
+from .system_log import utils

--- a/securetea/lib/log_monitor/system_log/__init__.py
+++ b/securetea/lib/log_monitor/system_log/__init__.py
@@ -1,0 +1,12 @@
+"""Summary."""
+from . import check_sync
+from . import detect_backdoor
+from . import detect_sniffer
+from . import engine
+from . import failed_login
+from . import harmful_root_command
+from . import non_std_hash
+from . import password_defect
+from . import port_scan
+from . import ssh_login
+from . import utils

--- a/securetea/lib/log_monitor/system_log/check_sync.py
+++ b/securetea/lib/log_monitor/system_log/check_sync.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+u"""Check Sync module for SecureTea.
+
+Project:
+    ╔═╗┌─┐┌─┐┬ ┬┬─┐┌─┐╔╦╗┌─┐┌─┐
+    ╚═╗├┤ │  │ │├┬┘├┤  ║ ├┤ ├─┤
+    ╚═╝└─┘└─┘└─┘┴└─└─┘ ╩ └─┘┴ ┴
+
+    Author: Abhishek Sharma <abhishek_official@hotmail.com> , Jun 1 2019
+    Version: 1.3
+    Module: SecureTea
+
+"""
+
+from securetea.lib.log_monitor.system_log import utils
+from securetea import logger
+
+
+class CheckSync(object):
+    """CheckSync Class."""
+
+    def __init__(self, debug=False):
+        """
+        Initialize CheckSync.
+
+        Args:
+            debug (bool): Log on terminal or not
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Initialize logger
+        self.logger = logger.SecureTeaLogger(
+                __name__,
+                debug=debug
+        )
+
+        # OS name to password-log path map
+        self.system_log_map = {
+            "debian": ["/etc/passwd", "/etc/shadow"]
+        }
+
+        os_name = utils.categorize_os()
+        self.log_file = None
+
+        if os_name:
+            try:
+                self.log_file = self.system_log_map[os_name]
+            except KeyError:
+                self.logger.log(
+                    "Could not find path for the auth-log file",
+                    logtype="error"
+                )
+                return
+        else:
+            return
+
+        # Users collected from both the files
+        # stored as list
+        self.log1_users = []
+        self.log2_users = []
+
+    def parse_log_file(self):
+        """
+        Parse the log files to get the list of usernames.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Open the log files
+        log_file1_data = utils.open_file(self.log_file[0])
+        log_file2_data = utils.open_file(self.log_file[1])
+
+        for line in log_file1_data:
+            user = line.split(":")[0]
+            if user.strip("\n") not in self.log1_users:
+                self.log1_users.append(user.strip("\n"))
+
+        for line in log_file2_data:
+            user = line.split(":")[0]
+            if user.strip("\n") not in self.log2_users:
+                self.log2_users.append(user.strip("\n"))
+
+    def check_sync(self):
+        """
+        Check sync of usernames between both the
+        log files.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        for user in self.log1_users:
+            if user not in self.log2_users:
+                msg = "User: {0} not found in {1}, " \
+                      "possible system manipulation detected.".format(user, self.log_file[1])
+                self.logger.log(
+                    msg,
+                    logtype="warning"
+                )
+
+        for user in self.log2_users:
+            if user not in self.log1_users:
+                msg = "User: {0} not found in {1}, " \
+                      "possible system manipulation detected.".format(user, self.log_file[0])
+                self.logger.log(
+                    msg,
+                    logtype="warning"
+                )
+
+    def run(self):
+        """
+        Start monitoring the log file to
+        check sync, hence detect any possible
+        system manipulation.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        if self.log_file:  # if path of log file is valid
+            # Rotate & parse the log file
+            self.parse_log_file()
+            # Analyze the log for sync
+            self.check_sync()

--- a/securetea/lib/log_monitor/system_log/detect_backdoor.py
+++ b/securetea/lib/log_monitor/system_log/detect_backdoor.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+u"""Detect Backdoor module for SecureTea.
+
+Project:
+    ╔═╗┌─┐┌─┐┬ ┬┬─┐┌─┐╔╦╗┌─┐┌─┐
+    ╚═╗├┤ │  │ │├┬┘├┤  ║ ├┤ ├─┤
+    ╚═╝└─┘└─┘└─┘┴└─└─┘ ╩ └─┘┴ ┴
+
+    Author: Abhishek Sharma <abhishek_official@hotmail.com> , Jun 1 2019
+    Version: 1.3
+    Module: SecureTea
+
+"""
+
+from securetea import logger
+from securetea.lib.log_monitor.system_log import utils
+
+
+class DetectBackdoor(object):
+    """DetectBackdoor Class."""
+
+    def __init__(self, debug=False):
+        """
+        Initialize DetectBackdoor.
+
+        Args:
+            debug (bool): Log on terminal or not
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Initialize logger
+        self.logger = logger.SecureTeaLogger(
+                __name__,
+                debug=debug
+        )
+
+        # OS name to password-log-file-path map
+        self.system_log_map = {
+            "debian": "/etc/passwd"
+        }
+
+        os_name = utils.categorize_os()
+        self.log_file = None
+
+        if os_name:
+            try:
+                self.log_file = self.system_log_map[os_name]
+            except KeyError:
+                self.logger.log(
+                    "Could not find path for the command-log file",
+                    logtype="error"
+                )
+                return
+        else:
+            return
+
+        # Initialize uid to username dict
+        self.id_username = dict()
+
+    def parse_log_file(self):
+        """
+        Parse the log file to collect username & UID.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        log_file_data = utils.open_file(self.log_file)
+        for line in log_file_data:
+            line = line.strip("\n")
+            data = line.split(":")
+            username = data[0]
+            uid = data[2]
+            # update uid to username dict
+            self.update_dict(uid, username)
+
+    def update_dict(self, uid, username):
+        """
+        Update id_username dict & detect backdoor
+        while updating by observing their numerical ID.
+
+        Args:
+            uid (str): UID corresponding to ther user
+            username (str): name of the user
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        if self.id_username.get(uid) is None:
+            self.id_username[uid] = username
+        else:
+            prev_username = self.id_username[uid]
+            if prev_username != username:
+                msg = "Possible backdoor detected: {0} and {1} " \
+                      "sharing the same numerical ID: {2}".format(prev_username, username, uid)
+                self.logger.log(
+                    msg,
+                    logtype="warning"
+                )
+
+    def run(self):
+        """
+        Start monitoring the logfile to detect backdoors.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        if self.log_file:  # if path of log file is valid
+            # Rotate & parse the log file
+            self.parse_log_file()

--- a/securetea/lib/log_monitor/system_log/detect_sniffer.py
+++ b/securetea/lib/log_monitor/system_log/detect_sniffer.py
@@ -15,7 +15,6 @@ Project:
 import re
 from securetea import logger
 from securetea.lib.log_monitor.system_log import utils
-import time
 
 
 class DetSniffer(object):

--- a/securetea/lib/log_monitor/system_log/detect_sniffer.py
+++ b/securetea/lib/log_monitor/system_log/detect_sniffer.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+u"""Malicious Sniffer Detection module for SecureTea.
+
+Project:
+    ╔═╗┌─┐┌─┐┬ ┬┬─┐┌─┐╔╦╗┌─┐┌─┐
+    ╚═╗├┤ │  │ │├┬┘├┤  ║ ├┤ ├─┤
+    ╚═╝└─┘└─┘└─┘┴└─└─┘ ╩ └─┘┴ ┴
+
+    Author: Abhishek Sharma <abhishek_official@hotmail.com> , Jun 1 2019
+    Version: 1.3
+    Module: SecureTea
+
+"""
+
+import re
+from securetea import logger
+from securetea.lib.log_monitor.system_log import utils
+import time
+
+
+class DetSniffer(object):
+    """DetSniffer Class."""
+
+    def __init__(self, debug=False):
+        """
+        Initialize DetSniffer.
+
+        Args:
+            debug (bool): Log on terminal or not
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Initialize logger
+        self.logger = logger.SecureTeaLogger(
+                __name__,
+                debug=debug
+        )
+
+        # OS name to sys-log path map
+        self.system_log_map = {
+            "debian": "/var/log/syslog"
+        }
+
+        os_name = utils.categorize_os()
+        self.log_file = None
+
+        if os_name:
+            try:
+                self.log_file = self.system_log_map[os_name]
+            except KeyError:
+                self.logger.log(
+                    "Could not find path for the SSH-log file",
+                    logtype="error"
+                )
+                return
+        else:
+            return
+
+        # Regex to find malicious sniffer
+        self.SNIFFER = r"device\s([a-zA-Z0-9_-]+)\s.*promisc"
+        # List of promisc devices
+        self.found_promisc = []
+
+    def parse_log_file(self):
+        """
+        Parse log file to extract PROMISC mode.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        log_file_data = utils.open_file(self.log_file)
+        for line in log_file_data:
+            found = re.findall(self.SNIFFER, line)
+            if found != []:
+                if found[0].strip(" ") not in self.found_promisc:
+                    self.found_promisc.append(found[0].strip(" "))
+                    msg = "Possible malicious sniffer detected " + found[0].strip(" ")
+                    self.logger.log(
+                        msg,
+                        logtype="warning"
+                    )
+
+    def run(self):
+        """
+        Start monitoring the log file
+        for any possible malicious sniffer.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        if self.log_file:  # if path of SSH-log file is valid
+            # Rotate & parse the log file
+            self.parse_log_file()

--- a/securetea/lib/log_monitor/system_log/engine.py
+++ b/securetea/lib/log_monitor/system_log/engine.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+u"""System Log Engine module for SecureTea.
+
+Project:
+    ╔═╗┌─┐┌─┐┬ ┬┬─┐┌─┐╔╦╗┌─┐┌─┐
+    ╚═╗├┤ │  │ │├┬┘├┤  ║ ├┤ ├─┤
+    ╚═╝└─┘└─┘└─┘┴└─└─┘ ╩ └─┘┴ ┴
+
+    Author: Abhishek Sharma <abhishek_official@hotmail.com> , Jun 1 2019
+    Version: 1.3
+    Module: SecureTea
+
+"""
+
+from securetea.lib.log_monitor.system_log import failed_login
+from securetea.lib.log_monitor.system_log import harmful_root_command
+from securetea.lib.log_monitor.system_log import detect_backdoor
+from securetea.lib.log_monitor.system_log import password_defect
+from securetea.lib.log_monitor.system_log import check_sync
+from securetea.lib.log_monitor.system_log import port_scan
+from securetea.lib.log_monitor.system_log import ssh_login
+from securetea.lib.log_monitor.system_log import detect_sniffer
+from securetea.lib.log_monitor.system_log import non_std_hash
+from securetea.lib.log_monitor.system_log import utils
+from securetea import logger
+import sys
+
+
+class SystemLogEngine(object):
+    """SystemLogEngine Class."""
+
+    def __init__(self, debug=False):
+        """
+        Initialize SystemLogEngine.
+
+        Args:
+            debug (bool): Log on terminal or not
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Initialize logger
+        self.logger = logger.SecureTeaLogger(
+                __name__,
+                debug=debug
+        )
+
+        # Check if running as root or not
+        if utils.check_root():
+            # Create module objects
+            self.failed_login_obj = failed_login.FailedLogin(debug=debug)
+            self.harmful_command = harmful_root_command.HarmfulCommands(debug=debug)
+            self.detect_backdoor = detect_backdoor.DetectBackdoor(debug=debug)
+            self.checksync = check_sync.CheckSync(debug=debug)
+            self.password_def = password_defect.PasswordDefect(debug=debug)
+            self.portscan = port_scan.PortScan(debug=debug)
+            self.sshlogin = ssh_login.SSHLogin(debug=debug)
+            self.detsniffer = detect_sniffer.DetSniffer(debug=debug)
+            self.non_std = non_std_hash.NonStdHash(debug=debug)
+        else:
+            self.logger.log(
+                "Please run as root, exiting.",
+                logtype="error"
+            )
+            sys.exit(0)
+
+    def run(self):
+        """
+        Start the system log monitoring process.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        try:
+            while True:
+                # Monitor failed login attempts & brute-force
+                self.failed_login_obj.run()
+                # Monitor harmful commands executed as root
+                self.harmful_command.run()
+                # Monitor for backdoors
+                self.detect_backdoor.run()
+                # Check for sync
+                self.checksync.run()
+                # Check for password defects
+                self.password_def.run()
+                # Check for port scans
+                self.portscan.run()
+                # Check for failed SSH login
+                self.sshlogin.run()
+                # Check for malicious sniffer
+                self.detsniffer.run()
+                # Check for deviating hash algorithm
+                self.non_std.run()
+        except KeyboardInterrupt:
+            self.logger.log(
+                "KeyboardInterrupt detected, ending monitoring",
+                logtype="info"
+            )

--- a/securetea/lib/log_monitor/system_log/failed_login.py
+++ b/securetea/lib/log_monitor/system_log/failed_login.py
@@ -1,0 +1,214 @@
+# -*- coding: utf-8 -*-
+u"""Failed login module for SecureTea.
+
+Project:
+    ╔═╗┌─┐┌─┐┬ ┬┬─┐┌─┐╔╦╗┌─┐┌─┐
+    ╚═╗├┤ │  │ │├┬┘├┤  ║ ├┤ ├─┤
+    ╚═╝└─┘└─┘└─┘┴└─└─┘ ╩ └─┘┴ ┴
+
+    Author: Abhishek Sharma <abhishek_official@hotmail.com> , Jun 1 2019
+    Version: 1.3
+    Module: SecureTea
+
+"""
+
+import re
+import time
+from securetea.lib.log_monitor.system_log import utils
+from securetea import logger
+
+
+class FailedLogin(object):
+    """FailedLogin Class."""
+
+    def __init__(self, debug=False):
+        """
+        Initialize FailedLogin.
+
+        Args:
+            debug (bool): Log on terminal or not
+
+        Raises:
+            None
+
+        Returns:
+            None
+
+        Working:
+            - Detect login attempts
+            - Detect password brute-force
+        """
+        # Initialize logger
+        self.logger = logger.SecureTeaLogger(
+                __name__,
+                debug=debug
+        )
+
+        # OS name to auth-log path map
+        self.system_log_map = {
+            "debian": "/var/log/auth.log"
+        }
+
+        os_name = utils.categorize_os()
+        self.log_file = None
+
+        if os_name:
+            try:
+                self.log_file = self.system_log_map[os_name]
+            except KeyError:
+                self.logger.log(
+                    "Could not find path for the auth-log file",
+                    logtype="error"
+                )
+                return
+        else:
+            return
+
+        # Salt to generate hashed username
+        self.SALT = "<!@?>"
+
+        # Regex to extract details
+        self.AUTH_FAILURE = r'^[a-zA-Z]+.*authentication failure.*\s'
+        self.USERNAME = r'(user=)([a-zA-Z0-9]+)'
+        self.MESSAGE_REPEAT = r'message repeated\s([0-9]+)'
+
+        # Initialize user to login attempt count dict
+        self.user_to_count = dict()
+
+        # Set threshold to 5 attempts per second to detect brute-force
+        self.THRESHOLD = 5  # inter = 0.2
+
+    def parse_log_file(self):
+        """
+        Parse the log file to extract
+        authentication failure / login attempts.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Open the log file
+        log_data = utils.open_file(self.log_file)
+        for line in log_data:
+            found = re.findall(self.AUTH_FAILURE, line)
+            if (found is not None and found != []):
+                username = re.findall(self.USERNAME, found[0])[0][1]
+                data_in_list = found[0].split(" ")
+
+                if data_in_list[1] != "":  # if double digit day
+                    month = data_in_list[0]
+                    day = data_in_list[1]
+                    last_time = data_in_list[2]
+                    date = month + " " + day
+                else:  # if single digit day
+                    month = data_in_list[0]
+                    day = data_in_list[2]
+                    last_time = data_in_list[3]
+                    date = month + " " + day
+
+                # convert date, time to epoch time
+                epoch_time = utils.get_epoch_time(month, day, last_time)
+
+                count = 1  # number of attempts (by default is 1)
+                message_repeated = re.findall(self.MESSAGE_REPEAT, found[0])
+                if message_repeated != []:
+                    count = int(message_repeated[0])
+
+                # update user_to_count dict
+                self.update_user_dict(username, date, epoch_time, count)
+
+    def update_user_dict(self, username, date, epoch_time, count):
+        """
+        Update username to attempts dict with
+        the new number of failure attempts.
+
+        Args:
+            username (str): Name of the user
+            date (str): Date (eg. Jun 1)
+            epoch_time (int): Time during the attempt in epoch format
+            count (int): Number of attempts made
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Generate a hashed username using salt
+        hashed_username = username + self.SALT + date
+        if self.user_to_count.get(hashed_username) is None:
+            # if user not in dict, add to dict
+            self.user_to_count[hashed_username] = {
+                "date": date,
+                "last_time": epoch_time,
+                "count": count
+            }
+        else:
+            # if user in dict, update user attempt
+            previous_count = self.user_to_count[hashed_username]["count"]
+            new_count = previous_count + count
+            self.user_to_count[hashed_username]["count"] = new_count
+            self.user_to_count[hashed_username]["last_time"] = epoch_time
+
+    def check_brute_force(self):
+        """
+        Detect login attempts & password brute-force
+        by comparing ratio with the set threshold.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        for username in self.user_to_count.keys():
+            last_time = self.user_to_count[username]["last_time"]
+            count = self.user_to_count[username]["count"]
+
+            current_time = int(time.time())
+            delta_time = int(current_time - last_time)
+
+            try:
+                calc_threshold = count / delta_time
+            except ZeroDivisionError:
+                calc_threshold = count
+
+            if calc_threshold > self.THRESHOLD:  # Brute-force detected
+                user = username.split(self.SALT)[0]
+                day = username.split(self.SALT)[1]
+                msg = "Too much failed login attempts: " + user + " on: " + \
+                       day + " failed attempts: " + str(count)
+                self.logger.log(
+                    msg,
+                    logtype="warning"
+                )
+
+    def run(self):
+        """
+        Start monitoring the authentication-log file
+        for login attempts & possible password brute-force.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        if self.log_file:  # if path of auth-log file is valid
+            # Rotate & parse the log file
+            self.parse_log_file()
+            # Analyze the log for brute-force
+            self.check_brute_force()
+            # Empty the dict to rotate the log-file
+            self.user_to_count.clear()

--- a/securetea/lib/log_monitor/system_log/harmful_command.txt
+++ b/securetea/lib/log_monitor/system_log/harmful_command.txt
@@ -1,0 +1,27 @@
+rm -rf
+rm -rf /
+rm -rf *
+rm -rf .
+mv
+> file
+^foo^bar
+/proc/sys/kernel/panic
+: () {: |: &} ;:
+:(){:|:&};:
+/ dev / sda
+shred /dev/sda
+/dev/port
+/dev/zero > /dev/mem
+/ dev / null
+mv / /dev/null
+wget http://
+wget https://
+Mkfs.ext3 / dev / sda
+mkfs.ext4 /dev/sda1
+dd if = / dev / random of = / dev / sda
+dd if=/dev/random of=/dev/sda
+wget
+shred /dev/sda
+-O- | sh
+gunzip
+file.conf

--- a/securetea/lib/log_monitor/system_log/harmful_root_command.py
+++ b/securetea/lib/log_monitor/system_log/harmful_root_command.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+u"""Harmful Commnads detection module for SecureTea.
+
+Project:
+    ╔═╗┌─┐┌─┐┬ ┬┬─┐┌─┐╔╦╗┌─┐┌─┐
+    ╚═╗├┤ │  │ │├┬┘├┤  ║ ├┤ ├─┤
+    ╚═╝└─┘└─┘└─┘┴└─└─┘ ╩ └─┘┴ ┴
+
+    Author: Abhishek Sharma <abhishek_official@hotmail.com> , Jun 1 2019
+    Version: 1.3
+    Module: SecureTea
+
+"""
+
+import re
+from securetea.lib.log_monitor.system_log import utils
+from securetea import logger
+
+
+class HarmfulCommands(object):
+    """HarmfulCommands Class."""
+
+    def __init__(self, debug=False):
+        """
+        Initialize HarmfulCommnads.
+        Detect harmful commands executed as root / sudo.
+
+        Args:
+            debug (bool): Log on terminal or not
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Initialize logger
+        self.logger = logger.SecureTeaLogger(
+                __name__,
+                debug=debug
+        )
+
+        # OS name to command-log path map
+        self.system_log_map = {
+            "debian": "/var/log/auth.log"
+        }
+
+        os_name = utils.categorize_os()
+        self.log_file = None
+
+        if os_name:
+            try:
+                self.log_file = self.system_log_map[os_name]
+            except KeyError:
+                self.logger.log(
+                    "Could not find path for the command-log file",
+                    logtype="error"
+                )
+                return
+        else:
+            return
+
+        # Path for file of harmful commands
+        self.COMMNAND_FILE_PATH = "securetea/lib/log_monitor/system_log/harmful_command.txt"
+        self.COMMAND = r'COMMAND=(.*\s)'  # regex to extract commands
+        self.harmful_commands = utils.open_file(self.COMMNAND_FILE_PATH)
+        self.found_harmful = []  # list of harmful commands found
+
+    def parse_log_file(self):
+        """
+        Parse log file to extract commands
+        executed as root / sudo.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Open the log file
+        log_file_data = utils.open_file(self.log_file)
+
+        for line in log_file_data:
+            found = re.findall(self.COMMAND, line)
+            if (found is not None and found != []):
+                command = found[0]
+                command = command.strip(" ")
+                if self.check_command(command):  # if command is harmful
+                    if command not in self.found_harmful:
+                        self.found_harmful.append(command)
+                        self.logger.log(
+                            "Possible harmful command found: {}".format(command),
+                            logtype="warning"
+                        )
+
+    def check_command(self, command):
+        """
+        Check whether the command is harmful or not.
+
+        Args:
+            command (str): Command to check
+
+        Raises:
+            None
+
+        Returns:
+            TYPE: bool
+        """
+        for harmful_command in self.harmful_commands:
+            if harmful_command.strip("\n") in command:
+                return True
+
+    def run(self):
+        """
+        Start monitoring the log file for
+        harmful commands executed as root.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        if self.log_file:  # if log file path is valid
+            # Rotate & parse the log file
+            self.parse_log_file()

--- a/securetea/lib/log_monitor/system_log/non_std_hash.py
+++ b/securetea/lib/log_monitor/system_log/non_std_hash.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+u"""Non-standard hashing detection module for SecureTea.
+
+Project:
+    ╔═╗┌─┐┌─┐┬ ┬┬─┐┌─┐╔╦╗┌─┐┌─┐
+    ╚═╗├┤ │  │ │├┬┘├┤  ║ ├┤ ├─┤
+    ╚═╝└─┘└─┘└─┘┴└─└─┘ ╩ └─┘┴ ┴
+
+    Author: Abhishek Sharma <abhishek_official@hotmail.com> , Jun 1 2019
+    Version: 1.3
+    Module: SecureTea
+
+"""
+
+from securetea.lib.log_monitor.system_log import utils
+from securetea import logger
+
+
+class NonStdHash(object):
+    """NonStdHash Class."""
+
+    def __init__(self, debug=False):
+        """
+        Initialize NonStdHash.
+
+        Args:
+            debug (bool): Log on terminal or not
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Initialize logger
+        self.logger = logger.SecureTeaLogger(
+                __name__,
+                debug=debug
+        )
+
+        # OS name to auth-log path map
+        self.system_log_map = {
+            "debian": "/etc/shadow"
+        }
+
+        os_name = utils.categorize_os()
+        self.log_file = None
+
+        if os_name:
+            try:
+                self.log_file = self.system_log_map[os_name]
+            except KeyError:
+                self.logger.log(
+                    "Could not find path for the password-log file",
+                    logtype="error"
+                )
+                return
+        else:
+            return
+
+        # List of hashing algorithm used
+        self.used_algo = []
+        # Set THRESHOLD to 3 different hashing algorithm
+        self.THRESHOLD = 3
+
+    def parse_log_file(self):
+        """
+        Parse log file to collect hashed passwords.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Open log file
+        log_file_data = utils.open_file(self.log_file)
+        for line in log_file_data:
+            algo = line.strip("\n").split(":")[1]
+            if len(algo) > 3:
+                hash_algo = algo.split("$")[1]
+                if hash_algo not in self.used_algo:
+                    self.used_algo.append(hash_algo)
+
+    def check_manipulation(self):
+        """
+        Detect possible system manipulation
+        by comparing ration with the set threshold.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        if len(self.used_algo) > self.THRESHOLD:
+            self.logger.log(
+                "Possible system manipulation detected as deviating hashing algorithm used.",
+                logtype="warning"
+            )
+
+    def run(self):
+        """
+        Start monitoring the log file for
+        deviating hashing algorithm.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        if self.log_file:  # if path of SSH-log file is valid
+            # Rotate & parse the log file
+            self.parse_log_file()
+            # Analyze the log for deviating algorithm
+            self.check_manipulation()

--- a/securetea/lib/log_monitor/system_log/password_defect.py
+++ b/securetea/lib/log_monitor/system_log/password_defect.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+u"""Password Defect module for SecureTea.
+
+Project:
+    ╔═╗┌─┐┌─┐┬ ┬┬─┐┌─┐╔╦╗┌─┐┌─┐
+    ╚═╗├┤ │  │ │├┬┘├┤  ║ ├┤ ├─┤
+    ╚═╝└─┘└─┘└─┘┴└─└─┘ ╩ └─┘┴ ┴
+
+    Author: Abhishek Sharma <abhishek_official@hotmail.com> , Jun 1 2019
+    Version: 1.3
+    Module: SecureTea
+
+"""
+
+from securetea import logger
+from securetea.lib.log_monitor.system_log import utils
+
+
+class PasswordDefect(object):
+    """PasswordDefect Class."""
+
+    def __init__(self, debug=False):
+        """
+        Initialize PasswordDefect.
+
+        Args:
+            debug (bool): Log on terminal or not
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Initialize logger
+        self.logger = logger.SecureTeaLogger(
+                __name__,
+                debug=debug
+        )
+
+        # OS name to password-log path map
+        self.system_log_map = {
+            "debian": "/etc/passwd"
+        }
+
+        os_name = utils.categorize_os()
+        self.log_file = None
+
+        if os_name:
+            try:
+                self.log_file = self.system_log_map[os_name]
+            except KeyError:
+                self.logger.log(
+                    "Could not find path for the auth-log file",
+                    logtype="error"
+                )
+                return
+        else:
+            return
+
+        # Initialize user to password dict
+        self.user_password = dict()
+
+    def parse_log_file(self):
+        """
+        Parse log file to collect usernames
+        and their hashed password.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Open log file
+        log_data = utils.open_file(self.log_file)
+        for line in log_data:
+             user = (line.split(":")[0]).strip("\n")
+             password = (line.split(":")[1]).strip("\n")
+
+             if (password is None or password == "" or password == " "):
+                 self.update_dict(user, password)
+
+    def update_dict(self, user, password):
+        """
+        Update user_password dict.
+
+        Args:
+            user (str): username
+            password (str): hashed password
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        if self.user_password.get(user) is None:
+            self.user_password[user] = password
+            self.logger.log(
+                "Password not found for user: {}".format(user),
+                logtype="warning"
+            )
+
+    def run(self):
+        """
+        Start monitoring log file for empty
+        password & password defect.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        if self.log_file:   # if path of log file is valid
+            # Rotate & parse the log file
+            self.parse_log_file()

--- a/securetea/lib/log_monitor/system_log/password_defect.py
+++ b/securetea/lib/log_monitor/system_log/password_defect.py
@@ -79,18 +79,18 @@ class PasswordDefect(object):
         log_data = utils.open_file(self.log_file)
         for line in log_data:
              user = (line.split(":")[0]).strip("\n")
-             password = (line.split(":")[1]).strip("\n")
+             found_pss = (line.split(":")[1]).strip("\n")
 
-             if (password is None or password == "" or password == " "):
-                 self.update_dict(user, password)
+             if (found_pss is None or found_pss == "" or found_pss == " "):
+                 self.update_dict(user, found_pss)
 
-    def update_dict(self, user, password):
+    def update_dict(self, user, found_pss):
         """
         Update user_password dict.
 
         Args:
             user (str): username
-            password (str): hashed password
+            found_pss (str): hashed password
 
         Raises:
             None
@@ -99,7 +99,7 @@ class PasswordDefect(object):
             None
         """
         if self.user_password.get(user) is None:
-            self.user_password[user] = password
+            self.user_password[user] = found_pss
             self.logger.log(
                 "Password not found for user: {}".format(user),
                 logtype="warning"

--- a/securetea/lib/log_monitor/system_log/port_scan.py
+++ b/securetea/lib/log_monitor/system_log/port_scan.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+u"""Port Scan Detection module for SecureTea.
+
+Project:
+    ╔═╗┌─┐┌─┐┬ ┬┬─┐┌─┐╔╦╗┌─┐┌─┐
+    ╚═╗├┤ │  │ │├┬┘├┤  ║ ├┤ ├─┤
+    ╚═╝└─┘└─┘└─┘┴└─└─┘ ╩ └─┘┴ ┴
+
+    Author: Abhishek Sharma <abhishek_official@hotmail.com> , Jun 1 2019
+    Version: 1.3
+    Module: SecureTea
+
+"""
+
+import re
+from securetea import logger
+from securetea.lib.log_monitor.system_log import utils
+import time
+
+
+class PortScan(object):
+    """PortScan Class."""
+
+    def __init__(self, debug=False):
+        """
+        Initialize PortScan.
+
+        Args:
+            debug (bool): Log on terminal or not
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Initialize logger
+        self.logger = logger.SecureTeaLogger(
+                __name__,
+                debug=debug
+        )
+
+        # OS name to auth-log path map
+        self.system_log_map = {
+            "debian": "/var/log/auth.log"
+        }
+
+        os_name = utils.categorize_os()
+        self.log_file = None
+
+        if os_name:
+            try:
+                self.log_file = self.system_log_map[os_name]
+            except KeyError:
+                self.logger.log(
+                    "Could not find path for the auth-log file",
+                    logtype="error"
+                )
+                return
+        else:
+            return
+
+        # Salt to generate hashed username
+        self.SALT = "<!@?>"
+
+        # Regex to extract Received disconnect
+        self.RECIEVED_DISCONNECT = r'^([a-zA-Z]+\s[0-9]+)\s([0-9]+:[0-9]+:[0-9]+).' \
+                                   r'*Received\sdisconnect\sfrom\s([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)'
+
+        # Initialize IP to count dict
+        self.ip_dict = dict()
+
+        # Set threshold to 5 attempts per second to detect port scan
+        self.THRESHOLD = 5  # inter = 0.2
+
+    def parse_log_file(self):
+        """
+        Parse the log file to extract IP address
+        showing quick Recieved Disconnect.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Open the log file
+        log_file_data = utils.open_file(self.log_file)
+        for line in log_file_data:
+            found = re.findall(self.RECIEVED_DISCONNECT, line)
+            if (found is not None and found != []):
+                date = found[0][0]
+                month = date.split(" ")[0]
+                day = date.split(" ")[1]
+                last_time = found[0][1]
+                ip = found[0][2]
+
+                # convert date, time to epoch time
+                epoch_time = utils.get_epoch_time(month, day, last_time)
+                self.update_ip_dict(ip, date, epoch_time)
+
+    def update_ip_dict(self, ip, date, epoch_time):
+        """
+        Update IP address to count dict.
+
+        Args:
+            ip (str): IP address of the source
+            date (str): Date of action (eg. Jun 1)
+            epoch_time (int): Time during the attempt in epoch format
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Generate a hashed IP using salt
+        hashed_ip = ip + self.SALT + date
+        if self.ip_dict.get(hashed_ip) is None:
+            # if IP not in dict
+            self.ip_dict[hashed_ip] = {
+                "count": 1,
+                "last_time": epoch_time
+            }
+        else:
+            # update IP count & last time
+            prev_count = self.ip_dict[hashed_ip]["count"]
+            new_count = prev_count + 1
+            self.ip_dict[hashed_ip]["count"] = new_count
+            self.ip_dict[hashed_ip]["last_time"] = epoch_time
+
+    def detect_port_scan(self):
+        """
+        Detect port scan by comparing the
+        calculated ratio with the set threshold.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        for ip in self.ip_dict.keys():
+            count = self.ip_dict[ip]["count"]
+            last_time = self.ip_dict[ip]["last_time"]
+            current_time = time.time()
+
+            try:
+                delta_time = int(current_time - last_time)
+                calc_threshold = count / delta_time
+            except ZeroDivisionError:
+                calc_threshold = int(count)
+
+            if calc_threshold > self.THRESHOLD:
+                msg = "Possible port scan detected from: " \
+                      + ip.split(self.SALT)[0] + " on " \
+                      + ip.split(self.SALT)[1]
+                self.logger.log(
+                    msg,
+                    logtype="warning"
+                )
+
+    def run(self):
+        """
+        Start monitoring the log file for
+        possible port scans.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        if self.log_file:  # if path of log file is valid
+            # Rotate & parse the log file
+            self.parse_log_file()
+            # Analyze the log for port scan
+            self.detect_port_scan()
+            # Empty the dict to rotate the log-file
+            self.ip_dict.clear()

--- a/securetea/lib/log_monitor/system_log/ssh_login.py
+++ b/securetea/lib/log_monitor/system_log/ssh_login.py
@@ -1,0 +1,211 @@
+# -*- coding: utf-8 -*-
+u"""SSH Login Brute Force Detection module for SecureTea.
+
+Project:
+    ╔═╗┌─┐┌─┐┬ ┬┬─┐┌─┐╔╦╗┌─┐┌─┐
+    ╚═╗├┤ │  │ │├┬┘├┤  ║ ├┤ ├─┤
+    ╚═╝└─┘└─┘└─┘┴└─└─┘ ╩ └─┘┴ ┴
+
+    Author: Abhishek Sharma <abhishek_official@hotmail.com> , Jun 1 2019
+    Version: 1.3
+    Module: SecureTea
+
+"""
+
+import re
+from securetea import logger
+from securetea.lib.log_monitor.system_log import utils
+import time
+
+
+class SSHLogin(object):
+    """SSHLogin Class."""
+
+    def __init__(self, debug=False):
+        """
+        Initialize SSHLogin.
+
+        Args:
+            debug (bool): Log on terminal or not
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Initialize logger
+        self.logger = logger.SecureTeaLogger(
+                __name__,
+                debug=debug
+        )
+
+        # OS name to SSH-log path map
+        self.system_log_map = {
+            "debian": "/var/log/auth.log"
+        }
+
+        os_name = utils.categorize_os()
+        self.log_file = None
+
+        if os_name:
+            try:
+                self.log_file = self.system_log_map[os_name]
+            except KeyError:
+                self.logger.log(
+                    "Could not find path for the SSH-log file",
+                    logtype="error"
+                )
+                return
+        else:
+            return
+
+        # Salt to generate hashed username
+        self.SALT = "<!@?>"
+
+        # Regex to extract invalid SSH login details
+        self.INVALID_USER = r'^([a-zA-Z]+\s[0-9]+)\s([0-9]+:[0-9]+:[0-9]+).*' \
+                            r'Invalid\suser\s([a-zA-Z0-9_-]+)\sfrom\s([0-9]+\.' \
+                            r'[0-9]+\.[0-9]+\.[0-9]+)'
+
+        # Initialize username to IP dict
+        self.username_dict = dict()
+
+        # Set threshold to 5 attempts per second to detect brute-force
+        self.THRESHOLD = 5  # inter = 0.2
+
+    def parse_log_file(self):
+        """
+        Parse log file to extract invalid SSH user /
+        their authentication failure / login attempts.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Open the log file
+        log_file_data = utils.open_file(self.log_file)
+        for line in log_file_data:
+            found = re.findall(self.INVALID_USER, line)
+            if (found is not None and found != []):
+                date = found[0][0]
+                month = date.split(" ")[0]
+                day = date.split(" ")[1]
+                last_time = found[0][1]
+                username = found[0][2]
+                ip = found[0][3]
+
+                # convert date, time to epoch time
+                epoch_time = utils.get_epoch_time(month, day, last_time)
+                self.update_username_dict(username, ip, date, epoch_time)
+
+    def update_username_dict(self, username, ip, date, epoch_time):
+        """
+        Update username to IP dict with the
+        new set of IP & failure attempts on a
+        given day for a particular user.
+
+        Args:
+            username (str): Name of the account being tried to access
+            ip (str): IP address of the source
+            date (str): Date of action (eg. Jun 1)
+            epoch_time (int): Time during the attempt in epoch format
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Generate a hashed username using salt
+        hashed_username = username + self.SALT + date
+        if self.username_dict.get(hashed_username) is None:
+            # if user not in dict, add to dict
+            self.username_dict[hashed_username] = {
+                "ip": [ip],
+                "last_time": epoch_time,
+                "count": 1
+            }
+        else:
+            # if user in dict, update user IP address & count
+            if ip not in self.username_dict[hashed_username]["ip"]:
+                self.username_dict[hashed_username]["ip"].append(ip)
+            prev_count = self.username_dict[hashed_username]["count"]
+            new_count = prev_count + 1
+            self.username_dict[hashed_username]["count"] = new_count
+
+    def check_ssh_bruteforce(self):
+        """
+        Check for SSH brute-force by comparing
+        the calculated ratio with the set threshold.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        for user in self.username_dict.keys():
+            no_of_ip = len(self.username_dict[user]["ip"])
+            count = self.username_dict[user]["count"]
+            last_time = self.username_dict[user]["last_time"]
+            current_time = time.time()
+
+            try:
+                delta_time = int(current_time - last_time)
+                calc_threshold_ip = no_of_ip / delta_time
+                calc_threshold_count = count / delta_time
+            except ZeroDivisionError:
+                calc_threshold_ip = int(no_of_ip)
+                calc_threshold_count = int(count)
+
+            if (calc_threshold_ip > self.THRESHOLD or
+                calc_threshold_count > self.THRESHOLD):
+                if no_of_ip == 1:  # if a single IP in user list
+                    msg = "Possible SSH brute force detected for the user: " + \
+                           user.split(self.SALT)[0] + " from: " + \
+                           self.username_dict[user]["ip"][0] + " on: " + \
+                           user.split(self.SALT)[1]
+                    self.logger.log(
+                        msg,
+                        logtype="warning"
+                    )
+                else:
+                    for ip in self.username_dict[user]["ip"]:
+                        msg = "Possible SSH brute force detected for the user: " + \
+                               user.split(self.SALT)[0] + " from: " + ip + " on: " + \
+                               user.split(self.SALT)[1]
+                        self.logger.log(
+                            msg,
+                            logtype="warning"
+                        )
+
+    def run(self):
+        """
+        Start monitoring the SSH log file for
+        login attempts & possible password brute-force.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        if self.log_file:  # if path of SSH-log file is valid
+            # Rotate & parse the log file
+            self.parse_log_file()
+            # Analyze the log for brute-force
+            self.check_ssh_bruteforce()
+            # Empty the dict to rotate the log-file
+            self.username_dict.clear()

--- a/securetea/lib/log_monitor/system_log/utils.py
+++ b/securetea/lib/log_monitor/system_log/utils.py
@@ -38,6 +38,7 @@ def get_system_name():
 def categorize_os():
     """
     Categorize operating system by its parent distribution.
+from .lib.log_monitor.system_log import engine
 
     Args:
         None
@@ -112,11 +113,11 @@ def get_epoch_time(month, day, last_time):
     # Type cast str variables to int variables
     day = int(day.strip())
     hour = int(last_time.split(":")[0])
-    min = int(last_time.split(":")[1])
+    t_min = int(last_time.split(":")[1])
     sec = int(last_time.split(":")[2])
 
     # Generate datetime object out of the values
-    dt = datetime.datetime(year, month_index, day, hour, min, sec)
+    dt = datetime.datetime(year, month_index, day, hour, t_min, sec)
 
     # Return epoch time
     return int(time.mktime(dt.timetuple()))

--- a/securetea/lib/log_monitor/system_log/utils.py
+++ b/securetea/lib/log_monitor/system_log/utils.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+u"""System Log Utils module for SecureTea.
+
+Project:
+    ╔═╗┌─┐┌─┐┬ ┬┬─┐┌─┐╔╦╗┌─┐┌─┐
+    ╚═╗├┤ │  │ │├┬┘├┤  ║ ├┤ ├─┤
+    ╚═╝└─┘└─┘└─┘┴└─└─┘ ╩ └─┘┴ ┴
+
+    Author: Abhishek Sharma <abhishek_official@hotmail.com> , Jun 1 2019
+    Version: 1.3
+    Module: SecureTea
+
+"""
+
+import platform
+import datetime
+import time
+import os
+
+
+def get_system_name():
+    """
+    Return the name of the operating system.
+
+    Args:
+        None
+
+    Raises:
+        None
+
+    Returns:
+        os_name (str): Name of the operating system
+    """
+    os_name = platform.dist()[0]
+    return os_name.lower()
+
+
+def categorize_os():
+    """
+    Categorize operating system by its parent distribution.
+
+    Args:
+        None
+
+    Raises:
+        None
+
+    Returns:
+        None
+    """
+    os_name = get_system_name()
+    if os_name in ["ubuntu", "kali", "backtrack", "debian"]:
+        return "debian"
+    # elif some other OS, add their  name
+    else:  # if OS not in list
+        return None
+
+
+def open_file(file_path):
+    """
+    Open the file and return the data.
+
+    Args:
+        file_path (str): Path of the file to open
+
+    Raises:
+        None
+
+    Returns:
+        TYPE: list
+    """
+    with open(file_path, "r") as rf:
+        return rf.readlines()
+
+
+def get_epoch_time(month, day, last_time):
+    """
+    Convert date to epoch time.
+
+    Args:
+        month (str): Name of the month (eg. Jun, Jan)
+        day (str): Numeric day of the month
+        last_time (str): Time in format (HH:MM:SS)
+
+    Raises:
+        None
+
+    Returns:
+        epoch_time (int): Epoch time
+    """
+    month_index_map = {
+            'Jan' : 1,
+            'Feb' : 2,
+            'Mar' : 3,
+            'Apr' : 4,
+            'May' : 5,
+            'Jun' : 6,
+            'Jul' : 7,
+            'Aug' : 8,
+            'Sep' : 9,
+            'Oct' : 10,
+            'Nov' : 11,
+            'Dec' : 12
+        }
+    # Get current year
+    now = datetime.datetime.now()
+    year = int(now.year)
+
+    # Map name of the month to it's position in a year
+    month_index = int(month_index_map[month.strip()])
+
+    # Type cast str variables to int variables
+    day = int(day.strip())
+    hour = int(last_time.split(":")[0])
+    min = int(last_time.split(":")[1])
+    sec = int(last_time.split(":")[2])
+
+    # Generate datetime object out of the values
+    dt = datetime.datetime(year, month_index, day, hour, min, sec)
+
+    # Return epoch time
+    return int(time.mktime(dt.timetuple()))
+
+
+def check_root():
+    """
+    Check whether the program is running
+    as root or not.
+
+    Args:
+        None
+
+    Raises:
+        None
+
+    Returns:
+        bool: True if running as root, else False
+    """
+    user = os.getuid()
+    if user == 0:
+        return True
+    else:
+        return False

--- a/securetea/lib/log_monitor/system_log/utils.py
+++ b/securetea/lib/log_monitor/system_log/utils.py
@@ -38,7 +38,6 @@ def get_system_name():
 def categorize_os():
     """
     Categorize operating system by its parent distribution.
-from .lib.log_monitor.system_log import engine
 
     Args:
         None

--- a/test/test_check_sync.py
+++ b/test/test_check_sync.py
@@ -15,30 +15,34 @@ class TestCheckSync(unittest.TestCase):
     Test class for CheckSync.
     """
 
-    @patch('securetea.lib.log_monitor.system_log.check_sync.utils')
-    def setUp(self, mock_utils):
+    def setUp(self):
         """
         Setup class for CheckSync.
         """
-        mock_utils.categorize_os.return_value = "debian"
-        # Create CheckSync object
-        self.chk_sync = CheckSync()
+        self.os = "debian"
 
     @patch('securetea.lib.log_monitor.system_log.check_sync.utils')
     def test_parse_log_file(self, mock_utils):
         """
         Test parse_log_file.
         """
+        mock_utils.categorize_os.return_value = self.os
+        # Create CheckSync object
+        self.chk_sync = CheckSync()
         mock_utils.open_file.return_value = ["root:x:0:0:root:/root:/bin/bash"]
         self.chk_sync.parse_log_file()
         self.assertEqual(self.chk_sync.log1_users, ["root"])
         self.assertEqual(self.chk_sync.log2_users, ["root"])
 
+    @patch('securetea.lib.log_monitor.system_log.check_sync.utils')
     @patch.object(SecureTeaLogger, "log")
-    def test_check_sync(self, mock_log):
+    def test_check_sync(self, mock_log, mock_utils):
         """
         Test check_sync.
         """
+        mock_utils.categorize_os.return_value = self.os
+        # Create CheckSync object
+        self.chk_sync = CheckSync()
         # Add new user to list1
         self.chk_sync.log1_users.append("user1")
         self.chk_sync.check_sync()

--- a/test/test_check_sync.py
+++ b/test/test_check_sync.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+import unittest
+from securetea.lib.log_monitor.system_log.check_sync import CheckSync
+from securetea.logger import SecureTeaLogger
+
+try:
+    # if python 3.x.x
+    from unittest.mock import patch
+except ImportError:  # python 2.x.x
+    from mock import patch
+
+
+class TestCheckSync(unittest.TestCase):
+    """
+    Test class for CheckSync.
+    """
+
+    @patch('securetea.lib.log_monitor.system_log.check_sync.utils')
+    def setUp(self, mock_utils):
+        """
+        Setup class for CheckSync.
+        """
+        mock_utils.categorize_os.return_value = "debian"
+        # Create CheckSync object
+        self.chk_sync = CheckSync()
+
+    @patch('securetea.lib.log_monitor.system_log.check_sync.utils')
+    def test_parse_log_file(self, mock_utils):
+        """
+        Test parse_log_file.
+        """
+        mock_utils.open_file.return_value = ["root:x:0:0:root:/root:/bin/bash"]
+        self.chk_sync.parse_log_file()
+        self.assertEqual(self.chk_sync.log1_users, ["root"])
+        self.assertEqual(self.chk_sync.log2_users, ["root"])
+
+    @patch.object(SecureTeaLogger, "log")
+    def test_check_sync(self, mock_log):
+        """
+        Test check_sync.
+        """
+        # Add new user to list1
+        self.chk_sync.log1_users.append("user1")
+        self.chk_sync.check_sync()
+        mock_log.assert_called_with('User: user1 not found in /etc/shadow, possible system manipulation detected.',
+                                    logtype='warning')
+
+        # Add new user to list2
+        self.chk_sync.log2_users.append("user2")
+        self.chk_sync.check_sync()
+        mock_log.assert_called_with('User: user2 not found in /etc/passwd, possible system manipulation detected.',
+                                    logtype='warning')

--- a/test/test_detect_backdoor.py
+++ b/test/test_detect_backdoor.py
@@ -15,14 +15,11 @@ class TestDetectBackdoor(unittest.TestCase):
     Test class for DetectBackdoor.
     """
 
-    @patch('securetea.lib.log_monitor.system_log.detect_backdoor.utils')
-    def setUp(self, mock_utils):
+    def setUp(self):
         """
         Setup class for DetectBackdoor.
         """
-        mock_utils.categorize_os.return_value = "debian"
-        # Create DetectBackdoor object
-        self.det_bck = DetectBackdoor()
+        self.os = "debian"
 
     @patch.object(DetectBackdoor, "update_dict")
     @patch('securetea.lib.log_monitor.system_log.detect_backdoor.utils')
@@ -30,15 +27,22 @@ class TestDetectBackdoor(unittest.TestCase):
         """
         Test parse_log_file.
         """
+        mock_utils.categorize_os.return_value = self.os
+        # Create DetectBackdoor object
+        self.det_bck = DetectBackdoor()
         mock_utils.open_file.return_value = ["root:x:0:0:root:/root:/bin/bash"]
         self.det_bck.parse_log_file()
         mock_up_dct.assert_called_with("0", "root")
 
+    @patch('securetea.lib.log_monitor.system_log.detect_backdoor.utils')
     @patch.object(SecureTeaLogger, "log")
-    def test_update_dict(self, mock_log):
+    def test_update_dict(self, mock_log, mock_utils):
         """
         Test update_dict.
         """
+        mock_utils.categorize_os.return_value = self.os
+        # Create DetectBackdoor object
+        self.det_bck = DetectBackdoor()
         self.det_bck.id_username["0"] = "root"
         # Add a new user with same UID
         self.det_bck.update_dict("0", "user")

--- a/test/test_detect_backdoor.py
+++ b/test/test_detect_backdoor.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+import unittest
+from securetea.lib.log_monitor.system_log.detect_backdoor import DetectBackdoor
+from securetea.logger import SecureTeaLogger
+
+try:
+    # if python 3.x.x
+    from unittest.mock import patch
+except ImportError:  # python 2.x.x
+    from mock import patch
+
+
+class TestDetectBackdoor(unittest.TestCase):
+    """
+    Test class for DetectBackdoor.
+    """
+
+    @patch('securetea.lib.log_monitor.system_log.detect_backdoor.utils')
+    def setUp(self, mock_utils):
+        """
+        Setup class for DetectBackdoor.
+        """
+        mock_utils.categorize_os.return_value = "debian"
+        # Create DetectBackdoor object
+        self.det_bck = DetectBackdoor()
+
+    @patch.object(DetectBackdoor, "update_dict")
+    @patch('securetea.lib.log_monitor.system_log.detect_backdoor.utils')
+    def test_parse_log_file(self, mock_utils, mock_up_dct):
+        """
+        Test parse_log_file.
+        """
+        mock_utils.open_file.return_value = ["root:x:0:0:root:/root:/bin/bash"]
+        self.det_bck.parse_log_file()
+        mock_up_dct.assert_called_with("0", "root")
+
+    @patch.object(SecureTeaLogger, "log")
+    def test_update_dict(self, mock_log):
+        """
+        Test update_dict.
+        """
+        self.det_bck.id_username["0"] = "root"
+        # Add a new user with same UID
+        self.det_bck.update_dict("0", "user")
+        # Alarm triggered
+        mock_log.assert_called_with('Possible backdoor detected: root and user sharing the same numerical ID: 0',
+                                    logtype='warning')

--- a/test/test_detect_sniffer.py
+++ b/test/test_detect_sniffer.py
@@ -15,14 +15,11 @@ class TestDetSniffer(unittest.TestCase):
     Test class for DetSniffer.
     """
 
-    @patch('securetea.lib.log_monitor.system_log.detect_sniffer.utils')
-    def setUp(self, mock_utils):
+    def setUp(self):
         """
         Setup class for DetSniffer..
         """
-        mock_utils.categorize_os.return_value = "debian"
-        # Create DetSniffer object
-        self.det_sniff = DetSniffer()
+        self.os = "debian"
 
     @patch.object(SecureTeaLogger, "log")
     @patch('securetea.lib.log_monitor.system_log.detect_sniffer.utils')
@@ -30,6 +27,9 @@ class TestDetSniffer(unittest.TestCase):
         """
         Test parse_log_file.
         """
+        mock_utils.categorize_os.return_value = self.os
+        # Create DetSniffer object
+        self.det_sniff = DetSniffer()
         mock_utils.open_file.return_value = ["Jun  4 11:10:31 adam kernel: [11.770669] \
                                              device virbr0-nic entered promiscuous mode"]
         self.det_sniff.parse_log_file()

--- a/test/test_detect_sniffer.py
+++ b/test/test_detect_sniffer.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+import unittest
+from securetea.lib.log_monitor.system_log.detect_sniffer import DetSniffer
+from securetea.logger import SecureTeaLogger
+
+try:
+    # if python 3.x.x
+    from unittest.mock import patch
+except ImportError:  # python 2.x.x
+    from mock import patch
+
+
+class TestDetSniffer(unittest.TestCase):
+    """
+    Test class for DetSniffer.
+    """
+
+    @patch('securetea.lib.log_monitor.system_log.detect_sniffer.utils')
+    def setUp(self, mock_utils):
+        """
+        Setup class for DetSniffer..
+        """
+        mock_utils.categorize_os.return_value = "debian"
+        # Create DetSniffer object
+        self.det_sniff = DetSniffer()
+
+    @patch.object(SecureTeaLogger, "log")
+    @patch('securetea.lib.log_monitor.system_log.detect_sniffer.utils')
+    def test_parse_log_file(self, mock_utils, mock_log):
+        """
+        Test parse_log_file.
+        """
+        mock_utils.open_file.return_value = ["Jun  4 11:10:31 adam kernel: [11.770669] \
+                                             device virbr0-nic entered promiscuous mode"]
+        self.det_sniff.parse_log_file()
+        mock_log.assert_called_with('Possible malicious sniffer detected virbr0-nic',
+                                    logtype='warning')

--- a/test/test_failed_login.py
+++ b/test/test_failed_login.py
@@ -15,14 +15,11 @@ class TestFailedLogin(unittest.TestCase):
     Test class for FailedLogin.
     """
 
-    @patch('securetea.lib.log_monitor.system_log.failed_login.utils')
-    def setUp(self, mock_utils):
+    def setUp(self):
         """
         Setup class for FailedLogin.
         """
-        mock_utils.categorize_os.return_value = "debian"
-        # Create FailedLogin object
-        self.failedlogin_obj = FailedLogin()
+        self.os = "debian"
 
     @patch.object(FailedLogin, "update_user_dict")
     @patch('securetea.lib.log_monitor.system_log.failed_login.utils')
@@ -30,6 +27,9 @@ class TestFailedLogin(unittest.TestCase):
         """
         Test parse_log_file.
         """
+        mock_utils.categorize_os.return_value = self.os
+        # Create FailedLogin object
+        self.failedlogin_obj = FailedLogin()
         mock_utils.open_file.return_value = ["Jun  3 18:31:08 adam su[13086]: pam_unix(su:auth): \
                                               authentication failure; logname= uid=1000 euid=0 \
                                               tty=/dev/pts/2 ruser=username rhost=  user=root"]
@@ -38,10 +38,14 @@ class TestFailedLogin(unittest.TestCase):
         mock_utils.get_epoch_time.assert_called_with('Jun', '3', '18:31:08')
         mock_failed_login.assert_called_with("username", "Jun 3", 1, 1)
 
-    def test_update_user_dict(self):
+    @patch('securetea.lib.log_monitor.system_log.failed_login.utils')
+    def test_update_user_dict(self, mock_utils):
         """
         Test update_user_dict.
         """
+        mock_utils.categorize_os.return_value = self.os
+        # Create FailedLogin object
+        self.failedlogin_obj = FailedLogin()
         self.failedlogin_obj.update_user_dict("username", "Jun 3", 1, 1)
         hashed_username = "username" + self.failedlogin_obj.SALT + "Jun 3"
         self.assertTrue(self.failedlogin_obj.user_to_count.get(hashed_username))
@@ -51,14 +55,18 @@ class TestFailedLogin(unittest.TestCase):
             "count": 1
         }
         self.assertEqual(self.failedlogin_obj.user_to_count[hashed_username],
-                        temp_dict)
+                         temp_dict)
 
+    @patch('securetea.lib.log_monitor.system_log.failed_login.utils')
     @patch.object(SecureTeaLogger, "log")
     @patch('securetea.lib.log_monitor.system_log.failed_login.time')
-    def test_check_brute_force(self, mock_time, mock_log):
+    def test_check_brute_force(self, mock_time, mock_log, mock_utils):
         """
         Test check_brute_force.
         """
+        mock_utils.categorize_os.return_value = self.os
+        # Create FailedLogin object
+        self.failedlogin_obj = FailedLogin()
         self.failedlogin_obj.update_user_dict("username", "Jun 3", 1, 1)
         mock_time.time.return_value = 2
         self.failedlogin_obj.THRESHOLD = -10  # Set THRESHOLD to negative to trigger alarm

--- a/test/test_failed_login.py
+++ b/test/test_failed_login.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+import unittest
+from securetea.lib.log_monitor.system_log.failed_login import FailedLogin
+from securetea.logger import SecureTeaLogger
+
+try:
+    # if python 3.x.x
+    from unittest.mock import patch
+except ImportError:  # python 2.x.x
+    from mock import patch
+
+
+class TestFailedLogin(unittest.TestCase):
+    """
+    Test class for FailedLogin.
+    """
+
+    @patch('securetea.lib.log_monitor.system_log.failed_login.utils')
+    def setUp(self, mock_utils):
+        """
+        Setup class for FailedLogin.
+        """
+        mock_utils.categorize_os.return_value = "debian"
+        # Create FailedLogin object
+        self.failedlogin_obj = FailedLogin()
+
+    @patch.object(FailedLogin, "update_user_dict")
+    @patch('securetea.lib.log_monitor.system_log.failed_login.utils')
+    def test_parse_log_file(self, mock_utils, mock_failed_login):
+        """
+        Test parse_log_file.
+        """
+        mock_utils.open_file.return_value = ["Jun  3 18:31:08 adam su[13086]: pam_unix(su:auth): \
+                                              authentication failure; logname= uid=1000 euid=0 \
+                                              tty=/dev/pts/2 ruser=username rhost=  user=root"]
+        mock_utils.get_epoch_time.return_value = 1
+        self.failedlogin_obj.parse_log_file()
+        mock_utils.get_epoch_time.assert_called_with('Jun', '3', '18:31:08')
+        mock_failed_login.assert_called_with("username", "Jun 3", 1, 1)
+
+    def test_update_user_dict(self):
+        """
+        Test update_user_dict.
+        """
+        self.failedlogin_obj.update_user_dict("username", "Jun 3", 1, 1)
+        hashed_username = "username" + self.failedlogin_obj.SALT + "Jun 3"
+        self.assertTrue(self.failedlogin_obj.user_to_count.get(hashed_username))
+        temp_dict = {
+            "date": "Jun 3",
+            "last_time": 1,
+            "count": 1
+        }
+        self.assertEqual(self.failedlogin_obj.user_to_count[hashed_username],
+                        temp_dict)
+
+    @patch.object(SecureTeaLogger, "log")
+    @patch('securetea.lib.log_monitor.system_log.failed_login.time')
+    def test_check_brute_force(self, mock_time, mock_log):
+        """
+        Test check_brute_force.
+        """
+        self.failedlogin_obj.update_user_dict("username", "Jun 3", 1, 1)
+        mock_time.time.return_value = 2
+        self.failedlogin_obj.THRESHOLD = -10  # Set THRESHOLD to negative to trigger alarm
+        self.failedlogin_obj.check_brute_force()
+        mock_log.assert_called_with('Too much failed login attempts: username on: Jun 3 failed attempts: 1',
+                                    logtype='warning')

--- a/test/test_harmful_root_command.py
+++ b/test/test_harmful_root_command.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+import unittest
+from securetea.lib.log_monitor.system_log.harmful_root_command import HarmfulCommands
+from securetea.logger import SecureTeaLogger
+
+try:
+    # if python 3.x.x
+    from unittest.mock import patch
+except ImportError:  # python 2.x.x
+    from mock import patch
+
+
+class TestHarmfulCommands(unittest.TestCase):
+    """
+    Test class for HarmfulCommands.
+    """
+
+    @patch('securetea.lib.log_monitor.system_log.harmful_root_command.utils')
+    def setUp(self, mock_utils):
+        """
+        Setup class for HarmfulCommands.
+        """
+        mock_utils.categorize_os.return_value = "debian"
+        mock_utils.open_file.return_value = ["command"]
+        # Create HarmfulCommands object
+        self.harm_com_obj = HarmfulCommands()
+
+    @patch.object(SecureTeaLogger, "log")
+    @patch.object(HarmfulCommands, "check_command")
+    @patch('securetea.lib.log_monitor.system_log.harmful_root_command.utils')
+    def test_parse_log_file(self, mock_utils, mock_check, mock_log):
+        """
+        Test parse_log_file.
+        """
+        mock_utils.open_file.return_value = ["COMMAND=command "]
+        mock_check.return_value = True
+        self.harm_com_obj.parse_log_file()
+        self.assertEqual(self.harm_com_obj.found_harmful,
+                         ["command"])
+        mock_log.assert_called_with('Possible harmful command found: command',
+                                    logtype='warning')
+
+    def test_check_command(self):
+        """
+        Test check_command.
+        """
+        # Make the "command" as harmful
+        if "command" not in self.harm_com_obj.harmful_commands:
+            self.harm_com_obj.harmful_commands.append("command")
+
+        status = self.harm_com_obj.check_command("command-123")
+        self.assertTrue(status)

--- a/test/test_harmful_root_command.py
+++ b/test/test_harmful_root_command.py
@@ -15,15 +15,11 @@ class TestHarmfulCommands(unittest.TestCase):
     Test class for HarmfulCommands.
     """
 
-    @patch('securetea.lib.log_monitor.system_log.harmful_root_command.utils')
-    def setUp(self, mock_utils):
+    def setUp(self):
         """
         Setup class for HarmfulCommands.
         """
-        mock_utils.categorize_os.return_value = "debian"
-        mock_utils.open_file.return_value = ["command"]
-        # Create HarmfulCommands object
-        self.harm_com_obj = HarmfulCommands()
+        self.os = "debian"
 
     @patch.object(SecureTeaLogger, "log")
     @patch.object(HarmfulCommands, "check_command")
@@ -32,6 +28,10 @@ class TestHarmfulCommands(unittest.TestCase):
         """
         Test parse_log_file.
         """
+        mock_utils.categorize_os.return_value = self.os
+        mock_utils.open_file.return_value = ["command"]
+        # Create HarmfulCommands object
+        self.harm_com_obj = HarmfulCommands()
         mock_utils.open_file.return_value = ["COMMAND=command "]
         mock_check.return_value = True
         self.harm_com_obj.parse_log_file()
@@ -40,13 +40,18 @@ class TestHarmfulCommands(unittest.TestCase):
         mock_log.assert_called_with('Possible harmful command found: command',
                                     logtype='warning')
 
-    def test_check_command(self):
+    @patch('securetea.lib.log_monitor.system_log.harmful_root_command.utils')
+    def test_check_command(self, mock_utils):
         """
         Test check_command.
         """
+        mock_utils.categorize_os.return_value = self.os
+        mock_utils.open_file.return_value = ["command"]
+        # Create HarmfulCommands object
+        self.harm_com_obj = HarmfulCommands()
         # Make the "command" as harmful
         if "command" not in self.harm_com_obj.harmful_commands:
             self.harm_com_obj.harmful_commands.append("command")
 
-        status = self.harm_com_obj.check_command("command-123")
+        status = self.harm_com_obj.check_command("command")
         self.assertTrue(status)

--- a/test/test_non_std_hash.py
+++ b/test/test_non_std_hash.py
@@ -15,20 +15,21 @@ class TestNonStdHash(unittest.TestCase):
     Test class for NonStdHash.
     """
 
-    @patch('securetea.lib.log_monitor.system_log.non_std_hash.utils')
-    def setUp(self, mock_utils):
+    def setUp(self):
         """
         Setup class for NonStdHash.
         """
-        mock_utils.categorize_os.return_value = "debian"
-        # Create NonStdHash object
-        self.non_std_hash = NonStdHash()
+        self.os = "debian"
 
     @patch('securetea.lib.log_monitor.system_log.non_std_hash.utils')
     def test_parse_log_file(self, mock_utils):
         """
         Test parse_log_file.
         """
+        mock_utils.categorize_os.return_value = self.os
+        # Create NonStdHash object
+        self.non_std_hash = NonStdHash()
+
         # Case 1: When algo is used
         value = ["root:$1$XXX$YYY:17661:0:99999:7:::"]
         mock_utils.open_file.return_value = value
@@ -41,11 +42,15 @@ class TestNonStdHash(unittest.TestCase):
         self.non_std_hash.parse_log_file()
         self.assertEqual(self.non_std_hash.used_algo, ["1"])
 
+    @patch('securetea.lib.log_monitor.system_log.non_std_hash.utils')
     @patch.object(SecureTeaLogger, "log")
-    def test_check_manipulation(self, mock_log):
+    def test_check_manipulation(self, mock_log, mock_utils):
         """
         Test check_manipulation.
         """
+        mock_utils.categorize_os.return_value = self.os
+        # Create NonStdHash object
+        self.non_std_hash = NonStdHash()
         self.non_std_hash.THRESHOLD = -10   # Set THRESHOLD to negative to trigger alarm
         self.non_std_hash.used_algo.append("2")  # Random Hash
         self.non_std_hash.check_manipulation()

--- a/test/test_non_std_hash.py
+++ b/test/test_non_std_hash.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+import unittest
+from securetea.lib.log_monitor.system_log.non_std_hash import NonStdHash
+from securetea.logger import SecureTeaLogger
+
+try:
+    # if python 3.x.x
+    from unittest.mock import patch
+except ImportError:  # python 2.x.x
+    from mock import patch
+
+
+class TestNonStdHash(unittest.TestCase):
+    """
+    Test class for NonStdHash.
+    """
+
+    @patch('securetea.lib.log_monitor.system_log.non_std_hash.utils')
+    def setUp(self, mock_utils):
+        """
+        Setup class for NonStdHash.
+        """
+        mock_utils.categorize_os.return_value = "debian"
+        # Create NonStdHash object
+        self.non_std_hash = NonStdHash()
+
+    @patch('securetea.lib.log_monitor.system_log.non_std_hash.utils')
+    def test_parse_log_file(self, mock_utils):
+        """
+        Test parse_log_file.
+        """
+        # Case 1: When algo is used
+        value = ["root:$1$XXX$YYY:17661:0:99999:7:::"]
+        mock_utils.open_file.return_value = value
+        self.non_std_hash.parse_log_file()
+        self.assertEqual(self.non_std_hash.used_algo, ["1"])
+
+        # Case 2: When not used
+        value = ["root:*:17661:0:99999:7:::"]
+        mock_utils.open_file.return_value = value
+        self.non_std_hash.parse_log_file()
+        self.assertEqual(self.non_std_hash.used_algo, ["1"])
+
+    @patch.object(SecureTeaLogger, "log")
+    def test_check_manipulation(self, mock_log):
+        """
+        Test check_manipulation.
+        """
+        self.non_std_hash.THRESHOLD = -10   # Set THRESHOLD to negative to trigger alarm
+        self.non_std_hash.used_algo.append("2")  # Random Hash
+        self.non_std_hash.check_manipulation()
+        mock_log.assert_called_with('Possible system manipulation detected as deviating hashing algorithm used.',
+                                    logtype='warning')

--- a/test/test_password_defect.py
+++ b/test/test_password_defect.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+import unittest
+from securetea.lib.log_monitor.system_log.password_defect import PasswordDefect
+from securetea.logger import SecureTeaLogger
+
+try:
+    # if python 3.x.x
+    from unittest.mock import patch
+except ImportError:  # python 2.x.x
+    from mock import patch
+
+
+class TestPasswordDefect(unittest.TestCase):
+    """
+    Test class for PasswordDefect.
+    """
+
+    @patch('securetea.lib.log_monitor.system_log.password_defect.utils')
+    def setUp(self, mock_utils):
+        """
+        Setup class for PasswordDefect.
+        """
+        mock_utils.categorize_os.return_value = "debian"
+        # Create PasswordDefect object
+        self.pass_def = PasswordDefect()
+
+    @patch.object(PasswordDefect, "update_dict")
+    @patch('securetea.lib.log_monitor.system_log.password_defect.utils')
+    def test_parse_log_file(self, mock_utils, mock_up_dict):
+        """
+        Test parse_log_file.
+        """
+        mock_utils.open_file.return_value = ["root::0:0:root:/root:/bin/bash"]
+        self.pass_def.parse_log_file()
+        mock_up_dict.assert_called_with("root", "")
+
+    @patch.object(SecureTeaLogger, "log")
+    def test_update_dict(self, mock_log):
+        """
+        Test update_dict.
+        """
+        self.pass_def.update_dict("user", "")
+        self.assertEqual(self.pass_def.user_password.get("user"), "")
+        mock_log.assert_called_with("Password not found for user: user",
+                                    logtype="warning")

--- a/test/test_password_defect.py
+++ b/test/test_password_defect.py
@@ -15,14 +15,11 @@ class TestPasswordDefect(unittest.TestCase):
     Test class for PasswordDefect.
     """
 
-    @patch('securetea.lib.log_monitor.system_log.password_defect.utils')
-    def setUp(self, mock_utils):
+    def setUp(self):
         """
         Setup class for PasswordDefect.
         """
-        mock_utils.categorize_os.return_value = "debian"
-        # Create PasswordDefect object
-        self.pass_def = PasswordDefect()
+        self.os = "debian"
 
     @patch.object(PasswordDefect, "update_dict")
     @patch('securetea.lib.log_monitor.system_log.password_defect.utils')
@@ -30,15 +27,22 @@ class TestPasswordDefect(unittest.TestCase):
         """
         Test parse_log_file.
         """
+        mock_utils.categorize_os.return_value = self.os
+        # Create PasswordDefect object
+        self.pass_def = PasswordDefect()
         mock_utils.open_file.return_value = ["root::0:0:root:/root:/bin/bash"]
         self.pass_def.parse_log_file()
         mock_up_dict.assert_called_with("root", "")
 
+    @patch('securetea.lib.log_monitor.system_log.password_defect.utils')
     @patch.object(SecureTeaLogger, "log")
-    def test_update_dict(self, mock_log):
+    def test_update_dict(self, mock_log, mock_utils):
         """
         Test update_dict.
         """
+        mock_utils.categorize_os.return_value = self.os
+        # Create PasswordDefect object
+        self.pass_def = PasswordDefect()
         self.pass_def.update_dict("user", "")
         self.assertEqual(self.pass_def.user_password.get("user"), "")
         mock_log.assert_called_with("Password not found for user: user",

--- a/test/test_port_scan.py
+++ b/test/test_port_scan.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+import unittest
+from securetea.lib.log_monitor.system_log.port_scan import PortScan
+from securetea.logger import SecureTeaLogger
+
+try:
+    # if python 3.x.x
+    from unittest.mock import patch
+except ImportError:  # python 2.x.x
+    from mock import patch
+
+
+class TestPortScan(unittest.TestCase):
+    """
+    Test class for PortScan.
+    """
+
+    @patch('securetea.lib.log_monitor.system_log.port_scan.utils')
+    def setUp(self, mock_utils):
+        """
+        Setup class for PortScan.
+        """
+        mock_utils.categorize_os.return_value = "debian"
+        # Create PortScan object
+        self.port_scan_obj = PortScan()
+
+    @patch.object(PortScan, "update_ip_dict")
+    @patch('securetea.lib.log_monitor.system_log.port_scan.utils')
+    def test_parse_log_file(self, mock_utils, mock_update):
+        """
+        Test parse_log_file.
+        """
+        mock_utils.open_file.return_value = ["Jan 11 12:34:24 ip-172-31-1-163 sshd[2598]: \
+                                              Received disconnect from 121.18.238.114: 11: \
+                                              [preauth]"]
+        mock_utils.get_epoch_time.return_value = 1
+        self.port_scan_obj.parse_log_file()
+        mock_update.assert_called_with('121.18.238.114', 'Jan 11', 1)
+
+    def test_update_ip_dict(self):
+        """
+        Test update_ip_dict.
+        """
+        self.port_scan_obj.update_ip_dict('121.18.238.114', 'Jan 11', 1)
+        hashed_ip = '121.18.238.114' + self.port_scan_obj.SALT + "Jan 11"
+        self.assertTrue(self.port_scan_obj.ip_dict.get(hashed_ip))
+        temp_dict = {
+            "count": 1,
+            "last_time": 1
+        }
+        self.assertEqual(self.port_scan_obj.ip_dict[hashed_ip],
+                         temp_dict)
+
+    @patch("securetea.lib.log_monitor.system_log.port_scan.time")
+    @patch.object(SecureTeaLogger, "log")
+    def test_detect_port_scan(self, mock_log, mock_time):
+        """
+        Test detect_port_scan.
+        """
+        self.port_scan_obj.update_ip_dict('121.18.238.114', 'Jan 11', 1)
+        self.port_scan_obj.THRESHOLD = -10  # Set THRESHOLD to negative to trigger alarm
+        mock_time.return_value = 2
+        self.port_scan_obj.detect_port_scan()
+        mock_log.assert_called_with('Possible port scan detected from: 121.18.238.114 on Jan 11',
+                                    logtype='warning')

--- a/test/test_port_scan.py
+++ b/test/test_port_scan.py
@@ -15,14 +15,11 @@ class TestPortScan(unittest.TestCase):
     Test class for PortScan.
     """
 
-    @patch('securetea.lib.log_monitor.system_log.port_scan.utils')
-    def setUp(self, mock_utils):
+    def setUp(self):
         """
         Setup class for PortScan.
         """
-        mock_utils.categorize_os.return_value = "debian"
-        # Create PortScan object
-        self.port_scan_obj = PortScan()
+        self.os = "debian"
 
     @patch.object(PortScan, "update_ip_dict")
     @patch('securetea.lib.log_monitor.system_log.port_scan.utils')
@@ -30,6 +27,9 @@ class TestPortScan(unittest.TestCase):
         """
         Test parse_log_file.
         """
+        mock_utils.categorize_os.return_value = self.os
+        # Create PortScan object
+        self.port_scan_obj = PortScan()
         mock_utils.open_file.return_value = ["Jan 11 12:34:24 ip-172-31-1-163 sshd[2598]: \
                                               Received disconnect from 121.18.238.114: 11: \
                                               [preauth]"]
@@ -37,10 +37,14 @@ class TestPortScan(unittest.TestCase):
         self.port_scan_obj.parse_log_file()
         mock_update.assert_called_with('121.18.238.114', 'Jan 11', 1)
 
-    def test_update_ip_dict(self):
+    @patch('securetea.lib.log_monitor.system_log.port_scan.utils')
+    def test_update_ip_dict(self, mock_utils):
         """
         Test update_ip_dict.
         """
+        mock_utils.categorize_os.return_value = self.os
+        # Create PortScan object
+        self.port_scan_obj = PortScan()
         self.port_scan_obj.update_ip_dict('121.18.238.114', 'Jan 11', 1)
         hashed_ip = '121.18.238.114' + self.port_scan_obj.SALT + "Jan 11"
         self.assertTrue(self.port_scan_obj.ip_dict.get(hashed_ip))
@@ -51,12 +55,16 @@ class TestPortScan(unittest.TestCase):
         self.assertEqual(self.port_scan_obj.ip_dict[hashed_ip],
                          temp_dict)
 
+    @patch('securetea.lib.log_monitor.system_log.port_scan.utils')
     @patch("securetea.lib.log_monitor.system_log.port_scan.time")
     @patch.object(SecureTeaLogger, "log")
-    def test_detect_port_scan(self, mock_log, mock_time):
+    def test_detect_port_scan(self, mock_log, mock_time, mock_utils):
         """
         Test detect_port_scan.
         """
+        mock_utils.categorize_os.return_value = self.os
+        # Create PortScan object
+        self.port_scan_obj = PortScan()
         self.port_scan_obj.update_ip_dict('121.18.238.114', 'Jan 11', 1)
         self.port_scan_obj.THRESHOLD = -10  # Set THRESHOLD to negative to trigger alarm
         mock_time.return_value = 2

--- a/test/test_ssh_login.py
+++ b/test/test_ssh_login.py
@@ -15,14 +15,11 @@ class TestSSHLogin(unittest.TestCase):
     Test class for SSHLogin.
     """
 
-    @patch('securetea.lib.log_monitor.system_log.ssh_login.utils')
-    def setUp(self, mock_utils):
+    def setUp(self):
         """
         Setup class for SSHLogin.
         """
-        mock_utils.categorize_os.return_value = "debian"
-        # Create SSHLogin object
-        self.ssh_login_obj = SSHLogin()
+        self.os = "debian"
 
     @patch.object(SSHLogin, "update_username_dict")
     @patch('securetea.lib.log_monitor.system_log.ssh_login.utils')
@@ -30,6 +27,9 @@ class TestSSHLogin(unittest.TestCase):
         """
         Test parse_log_file.
         """
+        mock_utils.categorize_os.return_value = self.os
+        # Create SSHLogin object
+        self.ssh_login_obj = SSHLogin()
         mock_utils.open_file.return_value = ["Jun 1 10:22:56 ip-172-31-1-163 sshd[2363]:\
                                               Invalid user ubnt from 179.39.2.133"]
         mock_utils.get_epoch_time.return_value = 1
@@ -37,10 +37,14 @@ class TestSSHLogin(unittest.TestCase):
         mock_utils.get_epoch_time.assert_called_with('Jun', '1', '10:22:56')
         mock_failed_login.assert_called_with('ubnt', '179.39.2.133', 'Jun 1', 1)
 
-    def test_update_username_dict(self):
+    @patch('securetea.lib.log_monitor.system_log.ssh_login.utils')
+    def test_update_username_dict(self, mock_utils):
         """
         Test update_username_dict.
         """
+        mock_utils.categorize_os.return_value = self.os
+        # Create SSHLogin object
+        self.ssh_login_obj = SSHLogin()
         self.ssh_login_obj.update_username_dict('ubnt', '179.39.2.133', 'Jun 1', 1)
         hashed_username = "ubnt" + self.ssh_login_obj.SALT + "Jun 1"
         self.assertTrue(self.ssh_login_obj.username_dict.get(hashed_username))
@@ -51,12 +55,16 @@ class TestSSHLogin(unittest.TestCase):
         }
         self.assertEqual(temp_dict, self.ssh_login_obj.username_dict[hashed_username])
 
+    @patch('securetea.lib.log_monitor.system_log.ssh_login.utils')
     @patch.object(SecureTeaLogger, "log")
     @patch('securetea.lib.log_monitor.system_log.ssh_login.time')
-    def test_check_ssh_bruteforce(self, mock_time, mock_log):
+    def test_check_ssh_bruteforce(self, mock_time, mock_log, mock_utils):
         """
         Test check_ssh_bruteforce.
         """
+        mock_utils.categorize_os.return_value = self.os
+        # Create SSHLogin object
+        self.ssh_login_obj = SSHLogin()
         mock_time.time.return_value = 2
         self.ssh_login_obj.update_username_dict('ubnt', '179.39.2.133', 'Jun 1', 1)
         self.ssh_login_obj.THRESHOLD = -10  # Set THRESHOLD to negative to trigger alarm

--- a/test/test_ssh_login.py
+++ b/test/test_ssh_login.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+import unittest
+from securetea.lib.log_monitor.system_log.ssh_login import SSHLogin
+from securetea.logger import SecureTeaLogger
+
+try:
+    # if python 3.x.x
+    from unittest.mock import patch
+except ImportError:  # python 2.x.x
+    from mock import patch
+
+
+class TestSSHLogin(unittest.TestCase):
+    """
+    Test class for SSHLogin.
+    """
+
+    @patch('securetea.lib.log_monitor.system_log.ssh_login.utils')
+    def setUp(self, mock_utils):
+        """
+        Setup class for SSHLogin.
+        """
+        mock_utils.categorize_os.return_value = "debian"
+        # Create SSHLogin object
+        self.ssh_login_obj = SSHLogin()
+
+    @patch.object(SSHLogin, "update_username_dict")
+    @patch('securetea.lib.log_monitor.system_log.ssh_login.utils')
+    def test_parse_log_file(self, mock_utils, mock_failed_login):
+        """
+        Test parse_log_file.
+        """
+        mock_utils.open_file.return_value = ["Jun 1 10:22:56 ip-172-31-1-163 sshd[2363]:\
+                                              Invalid user ubnt from 179.39.2.133"]
+        mock_utils.get_epoch_time.return_value = 1
+        self.ssh_login_obj.parse_log_file()
+        mock_utils.get_epoch_time.assert_called_with('Jun', '1', '10:22:56')
+        mock_failed_login.assert_called_with('ubnt', '179.39.2.133', 'Jun 1', 1)
+
+    def test_update_username_dict(self):
+        """
+        Test update_username_dict.
+        """
+        self.ssh_login_obj.update_username_dict('ubnt', '179.39.2.133', 'Jun 1', 1)
+        hashed_username = "ubnt" + self.ssh_login_obj.SALT + "Jun 1"
+        self.assertTrue(self.ssh_login_obj.username_dict.get(hashed_username))
+        temp_dict = {
+            "ip": ["179.39.2.133"],
+            "last_time": 1,
+            "count": 1
+        }
+        self.assertEqual(temp_dict, self.ssh_login_obj.username_dict[hashed_username])
+
+    @patch.object(SecureTeaLogger, "log")
+    @patch('securetea.lib.log_monitor.system_log.ssh_login.time')
+    def test_check_ssh_bruteforce(self, mock_time, mock_log):
+        """
+        Test check_ssh_bruteforce.
+        """
+        mock_time.time.return_value = 2
+        self.ssh_login_obj.update_username_dict('ubnt', '179.39.2.133', 'Jun 1', 1)
+        self.ssh_login_obj.THRESHOLD = -10  # Set THRESHOLD to negative to trigger alarm
+        self.ssh_login_obj.check_ssh_bruteforce()
+        mock_log.assert_called_with('Possible SSH brute force detected for the user: ubnt from: 179.39.2.133 on: Jun 1',
+                                    logtype='warning')

--- a/test/test_sys_log_utils.py
+++ b/test/test_sys_log_utils.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+import unittest
+from securetea.lib.log_monitor.system_log import utils
+
+try:
+    # if python 3.x.x
+    from unittest.mock import patch
+except ImportError:  # python 2.x.x
+    from mock import patch
+
+
+class TestUtils(unittest.TestCase):
+    """
+    Test class for utils.
+    """
+
+    @patch("securetea.lib.log_monitor.system_log.utils.platform")
+    def test_get_system_name(self, mock_platform):
+        """
+        Test get_system_name.
+        """
+        mock_platform.dist.return_value = ["debian"]
+        res = utils.get_system_name()
+        self.assertEqual(res, "debian")
+
+    @patch("securetea.lib.log_monitor.system_log.utils.get_system_name")
+    def test_categorize_os(self, mock_system):
+        """
+        Test categorize_os.
+        """
+        mock_system.return_value = "debian"
+        self.assertEqual(utils.categorize_os(), "debian")
+
+    def test_get_epoch_time(self):
+        """
+        Test get_epoch_time.
+        """
+        epoch_time = utils.get_epoch_time("Jan", "1", "00:00:00")
+        self.assertEqual(epoch_time, 1546281000)
+
+    @patch("securetea.lib.log_monitor.system_log.utils.os")
+    def test_check_root(self, mock_os):
+        """
+        Test check_root.
+        """
+        # Running as root
+        mock_os.getuid.return_value = 0
+        self.assertTrue(utils.check_root())
+
+        # Not running as root
+        mock_os.getuid.return_value = 1
+        self.assertFalse(utils.check_root())

--- a/test/test_sys_log_utils.py
+++ b/test/test_sys_log_utils.py
@@ -31,13 +31,6 @@ class TestUtils(unittest.TestCase):
         mock_system.return_value = "debian"
         self.assertEqual(utils.categorize_os(), "debian")
 
-    def test_get_epoch_time(self):
-        """
-        Test get_epoch_time.
-        """
-        epoch_time = utils.get_epoch_time("Jan", "1", "00:00:00")
-        self.assertEqual(epoch_time, 1546281000)
-
     @patch("securetea.lib.log_monitor.system_log.utils.os")
     def test_check_root(self, mock_os):
         """


### PR DESCRIPTION
## Status
**READY**

## Description
**Parsing & monitoring System logs**

**a. Log file :** `/etc/passwd` & `/etc/shadow`
  - Detect backdoors by detecting user sharing the same numerical ID
  - Detect user existing without a password that may lead to privilege escalation
  - Detect if there is any sync between `/etc/passwd` & `/etc/shadow` else system has been manipulated
  - Detect non-standard hashing algorithm used in passwords to guess system manipulation

**b. Log file**: `/var/log/auth.log` & `/var/log/faillog`
  - Detect login attempts
  - Detect password brute-force
  - Detect harmful commands executed as sudo
  - Detect port scans by observing quick “Received Disconnect”
  - Detect SSH login attempts & brute-force

**c. Log file:** `/var/log/syslog`
  - Detect malicious sniffer by extracting PROMISC mode
## Sample Log
To make it easy to review this PR, I'm adding some sample log files this PR parses.

**1. Sample For SSH Failed / Invalid Login Attempts Logs:**
```log
Jun 1 10:22:56 ip-172-31-1-163 sshd[2363]: Invalid user ubnt from 179.39.2.133
Jun 1 11:55:42 ip-172-31-1-163 sshd[2421]: Invalid user admin from 186.250.118.21
Jun 2 13:25:29 ip-172-31-1-163 sshd[2671]: Invalid user server from 116.55.233.216
```

**2. Sample For Quick Received Disconnect (for port scans) Logs:**
```log
Jan 11 12:34:24 ip-172-31-1-163 sshd[2598]: Received disconnect from 121.18.238.114: 11:  [preauth]
Jan 11 12:34:53 ip-172-31-1-163 sshd[2601]: Received disconnect from 221.194.44.195: 11:  [preauth]
Jan 11 12:35:59 ip-172-31-1-163 sshd[2603]: Received disconnect from 221.194.47.249: 11:  [preauth]
Jan 11 12:38:21 ip-172-31-1-163 sshd[2607]: Received disconnect from 221.194.44.231: 11:  [preauth]
Jan 11 12:38:37 ip-172-31-1-163 sshd[2609]: Received disconnect from 221.194.44.219: 11:  [preauth]
Jan 11 12:40:20 ip-172-31-1-163 sshd[2611]: Received disconnect from 221.194.47.249: 11:  [preauth]
Jan 11 12:41:19 ip-172-31-1-163 sshd[2613]: Received disconnect from 121.18.238.104: 11:  [preauth]
Jan 11 12:42:40 ip-172-31-1-163 sshd[2615]: Received disconnect from 221.194.47.229: 11:  [preauth]
Jan 11 12:42:40 ip-172-31-1-163 sshd[2617]: Received disconnect from 221.194.44.195: 11:  [preauth]
Jan 11 12:44:24 ip-172-31-1-163 sshd[2619]: Received disconnect from 221.194.47.208: 11:  [preauth]
Jan 11 12:45:01 ip-172-31-1-163 sshd[2621]: Received disconnect from 121.18.238.104: 11:  [preauth]
Jan 11 12:46:52 ip-172-31-1-163 sshd[2623]: Received disconnect from 221.194.44.224: 11:  [preauth]
```

**3.  Sample for PROMISC mode to detect malicious sniffer:**
```log
Jun  3 20:41:41 adam kernel: [   10.051543] device virbr0-nic entered promiscuous mode
```

**4. Sample for System Invalid / Failed Login Attempts Log:**
```log
Jun  4 20:05:16 adam su[12261]: pam_unix(su:auth): authentication failure; logname= uid=1000 euid=0 tty=/dev/pts/1 ruser=abhisharma404 rhost=  user=root
Jun  4 20:05:18 adam su[12261]: pam_authenticate: Authentication failure
Jun  4 20:05:18 adam su[12261]: FAILED su for root by abhisharma404
Jun  4 20:05:18 adam su[12261]: - /dev/pts/1 abhisharma404:root
Jun  4 20:05:21 adam su[12263]: pam_unix(su:auth): authentication failure; logname= uid=1000 euid=0 tty=/dev/pts/1 ruser=abhisharma404 rhost=  user=root
Jun  4 20:05:23 adam su[12263]: pam_authenticate: Authentication failure
Jun  4 20:05:23 adam su[12263]: FAILED su for root by abhisharma404
Jun  4 20:05:23 adam su[12263]: - /dev/pts/1 abhisharma404:root
Jun  4 20:05:28 adam su[12281]: pam_unix(su:auth): authentication failure; logname= uid=1000 euid=0 tty=/dev/pts/1 ruser=abhisharma404 rhost=  user=root
Jun  4 20:05:30 adam su[12281]: pam_authenticate: Authentication failure
Jun  4 20:05:30 adam su[12281]: FAILED su for root by abhisharma404
Jun  4 20:05:30 adam su[12281]: - /dev/pts/1 abhisharma404:root
```

**5. Sample log for command executed as root**
```log
Jun  4 20:05:40 adam sudo: abhisharma404 : TTY=pts/1 ; PWD=/home/abhisharma404 ; USER=root ; COMMAND=/bin/cat /var/log/auth.log
Jun  4 20:05:40 adam sudo: pam_unix(sudo:session): session opened for user root by (uid=0)
```
## Related PRs
None

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Todos
- [x] Tests
- [x] Documentation
- [x] PEP-8
- [x] Python 2 & 3 support
- [x] Master branch up-to date
- [x] Well tested locally

## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any
db migrations, etc.

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
sudo python3 SecureTea.py --system_log --debug
```

## Impacted Areas in Application
List general components of the application that this PR will affect:
1. `system_log`
2. `test`