### PR TITLE
Update .gitignore to ignore temp PCAP files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -312,3 +312,7 @@ API
 *.swp
 /build/
 /dist/
+
+## Temp PCAP files ##
+
+blocked.pcap


### PR DESCRIPTION
## Status
**READY**

## Description
Update .gitignore to ignore temp PCAP files, i.e. `blocked.pcap`.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Todos
- [ ] Tests
- [ ] Documentation

## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any
db migrations, etc.

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git pull --prune
git checkout <feature-branch>
```

## Impacted Areas in Application
1. `.gitignore` 
