### PR TITLE
Make Firewall smart: Learn bad IP address from System log monitor

### DIFF
--- a/securetea/lib/log_monitor/system_log/port_scan.py
+++ b/securetea/lib/log_monitor/system_log/port_scan.py
@@ -16,6 +16,7 @@ import re
 from securetea import logger
 from securetea.lib.log_monitor.system_log import utils
 from securetea.lib.osint.osint import OSINT
+from securetea.common import write_mal_ip
 import time
 
 
@@ -171,6 +172,8 @@ class PortScan(object):
                 )
                 # Generate CSV report using OSINT tools
                 self.osint_obj.perform_osint_scan(ip.split(self.SALT)[0].strip(" "))
+                # Write malicious IP to file, to teach Firewall about the IP
+                write_mal_ip(ip.split(self.SALT)[0].strip(" "))
 
     def run(self):
         """

--- a/securetea/lib/log_monitor/system_log/ssh_login.py
+++ b/securetea/lib/log_monitor/system_log/ssh_login.py
@@ -16,6 +16,7 @@ import re
 from securetea import logger
 from securetea.lib.log_monitor.system_log import utils
 from securetea.lib.osint.osint import OSINT
+from securetea.common import write_mal_ip
 import time
 
 
@@ -184,6 +185,8 @@ class SSHLogin(object):
                     )
                     # Generate CSV report using OSINT tools
                     self.osint_obj.perform_osint_scan(self.username_dict[user]["ip"][0].strip(" "))
+                    # Write malicious IP to file, to teach Firewall about the IP
+                    write_mal_ip(self.username_dict[user]["ip"][0].strip(" "))
                 else:
                     for ip in self.username_dict[user]["ip"]:
                         msg = "Possible SSH brute force detected for the user: " + \
@@ -195,6 +198,8 @@ class SSHLogin(object):
                         )
                         # Generate CSV report using OSINT tools
                         self.osint_obj.perform_osint_scan(ip.strip(" "))
+                        # Write malicious IP to file, to teach Firewall about the IP
+                        write_mal_ip(ip.strip(" "))
 
     def run(self):
         """

--- a/test/test_port_scan.py
+++ b/test/test_port_scan.py
@@ -56,14 +56,16 @@ class TestPortScan(unittest.TestCase):
         self.assertEqual(self.port_scan_obj.ip_dict[hashed_ip],
                          temp_dict)
 
+    @patch("securetea.lib.log_monitor.system_log.port_scan.write_mal_ip")
     @patch.object(OSINT, "perform_osint_scan")
     @patch('securetea.lib.log_monitor.system_log.port_scan.utils')
     @patch("securetea.lib.log_monitor.system_log.port_scan.time")
     @patch.object(SecureTeaLogger, "log")
-    def test_detect_port_scan(self, mock_log, mock_time, mock_utils, mck_osint):
+    def test_detect_port_scan(self, mock_log, mock_time, mock_utils, mck_osint, mck_wmip):
         """
         Test detect_port_scan.
         """
+        mck_wmip.return_value = True
         mck_osint.return_value = True
         mock_utils.categorize_os.return_value = self.os
         # Create PortScan object
@@ -74,3 +76,4 @@ class TestPortScan(unittest.TestCase):
         self.port_scan_obj.detect_port_scan()
         mock_log.assert_called_with('Possible port scan detected from: 121.18.238.114 on Jan 11',
                                     logtype='warning')
+        mck_wmip.assert_called_with("121.18.238.114")

--- a/test/test_ssh_login.py
+++ b/test/test_ssh_login.py
@@ -56,14 +56,16 @@ class TestSSHLogin(unittest.TestCase):
         }
         self.assertEqual(temp_dict, self.ssh_login_obj.username_dict[hashed_username])
 
+    @patch("securetea.lib.log_monitor.system_log.ssh_login.write_mal_ip")
     @patch.object(OSINT, "perform_osint_scan")
     @patch('securetea.lib.log_monitor.system_log.ssh_login.utils')
     @patch.object(SecureTeaLogger, "log")
     @patch('securetea.lib.log_monitor.system_log.ssh_login.time')
-    def test_check_ssh_bruteforce(self, mock_time, mock_log, mock_utils, mck_osint):
+    def test_check_ssh_bruteforce(self, mock_time, mock_log, mock_utils, mck_osint, mck_wmip):
         """
         Test check_ssh_bruteforce.
         """
+        mck_wmip.return_value = True
         mck_osint.return_value = True
         mock_utils.categorize_os.return_value = self.os
         # Create SSHLogin object
@@ -74,3 +76,4 @@ class TestSSHLogin(unittest.TestCase):
         self.ssh_login_obj.check_ssh_bruteforce()
         mock_log.assert_called_with('Possible SSH brute force detected for the user: ubnt from: 179.39.2.133 on: Jun 1',
                                     logtype='warning')
+        mck_wmip.assert_called_with("179.39.2.133")


### PR DESCRIPTION
## Status
**READY**

## Description
Make Firewall smart: Learn bad IP address from System log monitor to block them.
Learn bad IP address related to:
1. Port Scan
2. SSH brute-force attempts

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Todos
- [x] Tests
- [x] Documentation
- [x] PEP-8
- [x] Well tested locally
- [x] Master branch up-to date
- [x] Python 2 & 3 support

## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any
db migrations, etc.

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git pull --prune
git checkout <feature-branch>
```

## Impacted Areas in Application
List general components of the application that this PR will affect:
1. SecureTea System Log Monitor