### PR TITLE
Feature: Introduce SecureTea IoT mode

### DIFF
--- a/securetea/__init__.py
+++ b/securetea/__init__.py
@@ -83,3 +83,4 @@ from .lib.iot import iot_checker
 from .lib.iot import iot_logger
 from .modes import server_mode
 from .modes import system_mode
+from .modes import iot_mode

--- a/securetea/args/args_helper.py
+++ b/securetea/args/args_helper.py
@@ -165,6 +165,7 @@ class ArgsHelper(object):
         self.iot_checker_provided = False
         self.server_mode = False
         self.system_mode = False
+        self.iot_mode = False
 
         # Setup logger
         self.logger = logger.SecureTeaLogger(
@@ -712,6 +713,35 @@ class ArgsHelper(object):
                 if antivirus:
                     self.cred["antivirus"] = antivirus
 
+        if self.args.iot_mode and not self.iot_mode:
+            self.iot_mode = True
+            config_decision = str(input("[!] Do you want to use the saved configuratons? (Y/y): "))
+            if (config_decision.lower() == "Y" or
+                config_decision.lower() == "y"):
+                # Fetch credentials
+                creds = self.securetea_conf.get_creds(self.args)
+
+                if creds.get("firewall"):
+                    self.cred["firewall"] = creds["firewall"]
+                if creds.get("ids"):
+                    self.cred["ids"] = creds["ids"]
+                if creds.get("iot-check"):
+                    self.cred["iot-check"] = creds["iot-check"]
+            else:
+                # Start interactive setup for Firewall
+                firewall = self.configureFirewall()
+                # Start interactive setup for IDS
+                ids = self.configureIDS()
+                # Start interactive setup for IoT Checker
+                iot_check = self.configureIoTChecker()
+
+                if firewall:
+                    self.cred["firewall"] = firewall
+                if ids:
+                    self.cred["ids"] = ids
+                if iot_check:
+                    self.cred["iot-check"] = iot_check
+
         if not self.twitter_provided:
             if (self.args.twitter_api_key and
                 self.args.twitter_api_secret_key and
@@ -941,7 +971,8 @@ class ArgsHelper(object):
             self.antivirus_provided or
             self.iot_checker_provided or
             self.server_mode or
-            self.system_mode):
+            self.system_mode or
+            self.iot_mode):
             self.cred_provided = True
 
         return {
@@ -963,5 +994,6 @@ class ArgsHelper(object):
             'antivirus_provided': self.antivirus_provided,
             'iot_checker_provided': self.iot_checker_provided,
             'server_mode': self.server_mode,
-            'system_mode': self.system_mode
+            'system_mode': self.system_mode,
+            'iot_mode': self.iot_mode
         }

--- a/securetea/args/arguments.py
+++ b/securetea/args/arguments.py
@@ -590,5 +590,12 @@ def get_args():
         help="Start SecureTea in system mode"
     )
 
+    parser.add_argument(
+        '--iot-mode',
+        required=False,
+        action="store_true",
+        help="Start SecureTea in IoT mode"
+    )
+
     args = parser.parse_args()
     return args

--- a/securetea/core.py
+++ b/securetea/core.py
@@ -38,6 +38,7 @@ from securetea.lib.antivirus.secureTeaAntiVirus import SecureTeaAntiVirus
 from securetea.lib.iot import iot_checker
 from securetea.modes import server_mode
 from securetea.modes import system_mode
+from securetea.modes import iot_mode
 
 pynput_status = True
 
@@ -95,6 +96,7 @@ class SecureTea(object):
         self.iot_checker_provided = args_dict['iot_checker_provided']
         self.server_mode = args_dict["server_mode"]
         self.system_mode = args_dict["system_mode"]
+        self.iot_mode = args_dict["iot_mode"]
 
         # Initialize logger
         self.logger = logger.SecureTeaLogger(
@@ -302,6 +304,20 @@ class SecureTea(object):
             self.antivirus_provided = False
             self.system_log_provided = False
             self.ids_provided = False
+
+        # Check for IoT mode
+        if self.iot_mode:
+            self.logger.log(
+                "Starting SecureTea in IoT mode",
+                logtype="info"
+            )
+            # Initialize IoT Mode object
+            self.iot_mode_obj = iot_mode.IoTMode(cred=self.cred, debug=self.cred["debug"])
+            self.iot_mode_obj.start_iot_mode()
+            # Avoid multiple process of the objects created by the IoT mode, set their credentials to False
+            self.firewall_provided = False
+            self.ids_provided = False
+            self.iot_checker_provided = False
 
         if self.twitter_provided:
             self.twitter = secureTeaTwitter.SecureTeaTwitter(

--- a/securetea/modes/__init__.py
+++ b/securetea/modes/__init__.py
@@ -1,3 +1,4 @@
 """Summary."""
 from . import server_mode
 from . import system_mode
+from . import iot_mode

--- a/securetea/modes/iot_mode.py
+++ b/securetea/modes/iot_mode.py
@@ -1,0 +1,225 @@
+# -*- coding: utf-8 -*-
+u"""IoT Mode for SecureTea.
+
+Project:
+    ╔═╗┌─┐┌─┐┬ ┬┬─┐┌─┐╔╦╗┌─┐┌─┐
+    ╚═╗├┤ │  │ │├┬┘├┤  ║ ├┤ ├─┤
+    ╚═╝└─┘└─┘└─┘┴└─└─┘ ╩ └─┘┴ ┴
+    Author: Abhishek Sharma <abhishek_official@hotmail.com> , Jul 31 2019
+    Version: 1.5.1
+    Module: SecureTea
+
+"""
+
+# Import all the modules necessary for IoT mode
+from securetea.lib.ids import secureTeaIDS
+from securetea.lib.firewall import secureTeaFirewall
+from securetea.lib.iot import iot_checker
+from securetea import logger
+
+import multiprocessing
+import sys
+
+
+class IoTMode(object):
+    """IoTMode class."""
+
+    def __init__(self, debug=False, cred=None):
+        """
+        Initialize IoTMode.
+
+        Args:
+            debug (bool): Log on terminal or not
+            cred (dict): Configuration credentials
+
+        Raises:
+            None
+
+        Returns
+            None
+        """
+        self.debug = debug
+
+        # Initialize logger
+        self.logger = logger.SecureTeaLogger(
+                __name__,
+                debug=self.debug
+        )
+
+        # Initialize credentials
+        if cred is not None:
+            self.cred = cred
+        else:
+            self.logger.log(
+                "No configuraton parameters found, exiting",
+                logtype="error"
+            )
+            sys.exit(0)
+
+        # Initialize objects presence as false
+        self.firewall = False
+        self.ids = False
+        self.iot_checker = False
+
+        # Initialize empty process pool list
+        self.process_pool = list()
+
+    def create_objects(self):
+        """
+        Create module (Firewall, IDS, IoT Checker) objects
+        if configuraton parameters are available for these.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        if self.cred.get("firewall"):
+            try:
+                self.logger.log(
+                    "Initializing Firewall object",
+                    logtype="info"
+                )
+                # Initialize Firewall object
+                self.firewallObj = secureTeaFirewall.SecureTeaFirewall(cred=self.cred,
+                                                                       debug=self.debug)
+                self.firewall = True
+                self.logger.log(
+                    "Initialized Firewall object",
+                    logtype="info"
+                )
+            except KeyError:
+                self.logger.log(
+                    "Firewall configuration parameter not configured.",
+                    logtype="error"
+                )
+            except Exception as e:
+                self.logger.log(
+                    "Error occured: " + str(e),
+                    logtype="error"
+                )
+
+        if self.cred.get("ids"):
+            try:
+                self.logger.log(
+                    "Initializing IDS object",
+                    logtype="info"
+                )
+                # Initialize IDS object
+                self.ids_obj = secureTeaIDS.SecureTeaIDS(cred=self.cred['ids'],
+                                                         debug=self.debug)
+                self.ids = True
+                self.logger.log(
+                    "Initialized IDS object",
+                    logtype="info"
+                )
+            except KeyError:
+                self.logger.log(
+                    "Intrusion Detection System (IDS) parameter not configured.",
+                    logtype="error"
+                )
+            except Exception as e:
+                self.logger.log(
+                    "Error occured: " + str(e),
+                    logtype="error"
+                )
+
+            try:
+                self.logger.log(
+                    "Initializing IoT checker object",
+                    logtype="info"
+                )
+                # Initialize IoT Checker object
+                self.iot_checker_obj = iot_checker.IoTChecker(debug=self.debug,
+                                                              api_key=self.cred['iot-check']['shodan-api-key'],
+                                                              ip=self.cred['iot-check']['ip'])
+            except KeyError:
+                self.logger.log(
+                    "IoT checker parameters not configured.",
+                    logtype="error"
+                )
+            except Exception as e:
+                self.logger.log(
+                    "Error occured: " + str(e),
+                    logtype="error"
+                )
+
+    def create_process(self):
+        """
+        Create process for the initialized objects.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        if self.firewall:  # if Firewall object is initialized
+            firewall_process = multiprocessing.Process(target=self.firewallObj.start_firewall)
+            self.process_pool.append(firewall_process)
+
+        if self.ids:  # if IDS object is initialized
+            ids_process = multiprocessing.Process(target=self.ids_obj.start_ids)
+            self.process_pool.append(ids_process)
+
+        if self.iot_checker:  # if IoT object is initialized
+            iot_checker_process = multiprocessing.Process(target=self.iot_checker_obj.check_shodan_range)
+            self.process_pool.append(iot_checker_process)
+
+    def start_process(self):
+        """
+        Start all the process in the process pool
+        and terminate gracefully in Keyboard Interrupt.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        try:
+            for process in self.process_pool:
+                process.start()
+
+            for process in self.process_pool:
+                process.join()
+
+        except KeyboardInterrupt:
+            for process in self.process_pool:
+                process.terminate()
+
+        except Exception as e:
+            self.logger.log(
+                "Error occured: " + str(e),
+                logtype="error"
+            )
+
+    def start_iot_mode(self):
+        """
+        Start SecureTea in IoT mode.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Create / initialize required objects
+        self.create_objects()
+        # Create process for the objects
+        self.create_process()
+        # Start the process
+        self.start_process()


### PR DESCRIPTION
## Status
**READY**

## Description
SecureTea IoT mode, this mode includes the running of the following modules:
1. Firewall
2. Intrusion Detection System (IDS)
3. IoT Checker

The mode can be easily started using the args `--iot-mode`, the following command is what follows:
1. Normal
`sudo SecureTea.py --iot-mode`
2. Debug / Developer
`sudo SecureTea.py --debug --iot-mode`

Upon this, it will ask whether to load the previously saved configurations or enter a new one. Choosing to go with a new configuration will start an interactive setup of the respected modules. Also, user can skip any module among the above 3 modules.

It makes a lot easier to configure SecureTea, with IoT mode they can easily secure their IoT devices. They don't need to bother about the various arguments or the toughness of setting up SecureTea individual modules like we have been doing earlier. Also, since they can skip any module among the above 3 it is not necessary to configure them all.

## Reference diagram
![image](https://user-images.githubusercontent.com/29058921/62295885-a7ca0800-b48b-11e9-8acb-68e9648494e3.png)

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Todos
- [x] Tests
- [x] Documentation
- [x] PEP-8
- [x] Well tested locally
- [x] Master branch up-to date
- [x] Python 2 & 3 support

## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any
db migrations, etc.

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
sudo python3 SecureTea.py --debug --iot-mode
```

## Impacted Areas in Application
List general components of the application that this PR will affect:
1. SecureTea IoT Mode