### PR TITLE
Added distro module instead of platform module.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ lxml
 ipwhois
 shodan
 future
+distro

--- a/setup.py
+++ b/setup.py
@@ -17,12 +17,13 @@ Attributes:
 
 from setuptools import find_packages
 from setuptools import setup
+import distro
 import platform
 import subprocess
 import re
 
 
-os_name = platform.dist()[0]
+os_name = distro.linux_distribution()[0]
 if not os_name:
     if 'amzn' in platform.uname()[2]:
         os_name = 'centos'
@@ -134,7 +135,7 @@ def install_dependency(dependency, command):
 def check_dependency():
     """Check for the dependencies in the system."""
     # categorize OS
-    if os_name.lower() in ["ubuntu", "kali", "debian"]:
+    if os_name.lower() in ["ubuntu", "kali", "debian","kali gnu/linux"]:
         system = "debian"
     # elif some other based OS
     else:  # if OS not in listing


### PR DESCRIPTION

## Description
The setup.py uses the platform module which doesn't have a method called dist, so fixed this issue by adding a new module called distro to provide the same functionalities.

Added kali gnu/Linux to the list of known distro, as recent kali os have their distro name like that.

Added distro package to the requirements.txt 

## Steps to Test or Reproduce

Clone the GitHub repo
cd into it 
sudo python3 setup.py install
This throws an error

  "os_name = platform.dist()[0]
AttributeError: module 'platform' has no attribute 'dist"


## Impacted Areas in Application
1.) setup.py
2.)requirements.txt

* 
