### PR TITLE
Fix For "Attribute dist not found in platform"

### DIFF
--- a/SecureTea.py
+++ b/SecureTea.py
@@ -3,6 +3,7 @@
 """Docstring."""
 import os
 import platform
+import distro
 import time
 
 from securetea.core import SecureTea
@@ -16,8 +17,9 @@ if __name__ == '__main__':
         platfom = platform.system()
         if platfom == 'Linux':
             command = 'sudo pm-suspend'
-            os_name = platform.dist()[0]
-            os_major_version = platform.dist()[1].split('.')[0]
+            os_name = distro.linux_distribution()[0]
+            os_major_version = distro.linux_distribution()[1].split('.')[0]
+
             if os_name == 'Ubuntu' and int(os_major_version) >= 16:
                 command = 'systemctl suspend'
             os.system(command)


### PR DESCRIPTION
## Status
**READY/IN DEVELOPMENT/HOLD**

## Description
While running `sudo python3 SecureTea.py --server-mode`    it resulted in  "Attribute dist not found in platform" so fixed it with importing distro again


## Impacted Areas in Application
List general components of the application that this PR will affect: ` SecureTea.py`

* 
