### PR TITLE
Prerequisites installer for clean installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@
 
 Before installing, please make sure to install the **[pre-requisites](/doc/en-US/user_guide.md#pre-requisites)**.
 
+To install software requirements:
+
+For apt package manager based systems:
+```shell
+$ sudo bash install install_dependencies_apt.sh
+```
+For yum package manager based systems:
+```shell
+$ sudo bash install install_dependencies_yum.sh
+```
+
 You can install SecureTea from PyPi package manager using the following command:
 
 `$ sudo python3 -m pip install securetea`
@@ -69,7 +80,6 @@ You can install SecureTea using the latest repository:
 ```shell
 git clone https://github.com/OWASP/SecureTea-Project.git
 cd SecureTea-Project/
-sudo python3 -m pip install -r requirements.txt
 sudo python3 setup.py install
 ```
 

--- a/doc/en-US/user_guide.md
+++ b/doc/en-US/user_guide.md
@@ -139,10 +139,19 @@ OWASP SecureTea Tool project runs on Linux, Windows and macOS operating systems.
 -  Clam AV
 
 #### Installing pre-requisites
+Download and Extract the zip file, or use command
+```git clone https://github.com/OWASP/SecureTea-Project.git```
+
+Navigate inside the folder ```SecureTea-Project``` , open Terminal inside and run the following commands
+
 For apt package manager based systems:
-  + $ sudo bash install install_dependencies_apt.sh
+```shell
+$ sudo bash install install_dependencies_apt.sh
+```
 For yum package manager based systems:
-  + $ sudo bash install install_dependencies_yum.sh
+```shell
+$ sudo bash install install_dependencies_yum.sh
+```
 Python:<br>
 https://www.python.org/
 
@@ -213,10 +222,7 @@ Installing from GitHub involves the following steps:
 2.  Navigate into the project directory:
 `$ cd SecureTea-Project`
 
-3.  Install Python dependencies:
-`$ sudo python3 -m pip install -r requirements.txt`
-
-4.  Install SecureTea package:
+3.  Install SecureTea package:
 `$ sudo python3 setup.py install`
 
 If done, proceed to [After installation](#after-installation)
@@ -231,10 +237,7 @@ Installing from Zip involves the following steps:
 3.  Navigate into the project directory:
 `$ cd SecureTea-Project`
 
-4.  Install python dependencies
-`$ sudo python3 -m pip install -r requirements.txt`
-
-5.  Install SecureTea package
+4.  Install SecureTea package
 `$ sudo python3 setup.py install`
 
 Tip: Incase of any error during installation related to NetfilterQueue, try using `$ sudo apt-get install build-essential python-dev libnetfilter-queue-dev` to resolve the error.
@@ -884,12 +887,12 @@ sudo python3 SecureTea.py --ids
 
 What are **thresholds**?
 <br>
-It simply represents the number of times you want to ignore the possibility of an attack. In other words, it is the extent to which IDS will not bother to inform you about the attack, once it crosses the limit (here threshold), it will start notifying you about the possible attack. Lower the number is, the more sensitive IDS is, and may also give rise to false alarms. Higher the number is, the less sensitive IDS is, it may give rise to less false positives but at the same time choosing a very high number is not suggested either. Choose a mid range number within (10-100) to be on the safer side while keeping alarms of false positives to the minimal.
+It simply represents the number of times you want to ignore the possibility of an attack. In other words, it is the extent to which IDS will not bother to inform you about the attack. Once it crosses the limit (here threshold), it will start notifying you about the possible attack. The lower the number is, the more sensitive IDS is, and may also give rise to false alarms. The higher the number is, the less sensitive IDS is, it may give rise to less false positives but at the same time choosing a very high number is not suggested either. Choose a mid range number within (10-100) to be on the safer side while keeping alarms of false positives to the minimal.
 <br>
 
 What is **eligibility traces**?
 <br>
-Eligibility traces are one of the basic mechanisms of reinforcement learning. For example, in the popular TD($\lambda $) algorithm, the $\lambda $ refers to the use of an eligibility trace. Almost any temporal-difference (TD) method, such as Q-learning or Sarsa, can be combined with eligibility traces to obtain a more general method that may learn more efficiently.
+Eligibility traces are one of the basic mechanisms of reinforcement learning. For example, in the popular TD(λ) algorithm, the λ refers to the use of an eligibility trace. Almost any temporal-difference (TD) method, such as Q-learning or Sarsa, can be combined with eligibility traces to obtain a more general method that may learn more efficiently.
 
 There are two ways to view eligibility traces. The more theoretical view, which we emphasize here, is that they are a bridge from TD to Monte Carlo methods. When TD methods are augmented with eligibility traces, they produce a family of methods spanning a spectrum that has Monte Carlo methods at one end and one-step TD methods at the other. In between are intermediate methods that are often better than either extreme method. In this sense eligibility traces unify TD and Monte Carlo methods in a valuable and revealing way.
 
@@ -1174,6 +1177,7 @@ The report will contain the following fields:
 3. WHOIS lookup
 4. Other important details
 <br>
+
 **Running Intrusion Detection System**
 
 ![Running IDS Recon](/img/ids_demo.gif)

--- a/install_dependencies_apt.sh
+++ b/install_dependencies_apt.sh
@@ -21,3 +21,4 @@ apt-get install python3.8
 apt-get install python3-pip
 python3 -m pip install -r requirements.txt
 python3 -m pip install git+https://github.com/kti/python-netfilterqueue
+python3 -m pip install -r requirements.txt

--- a/install_dependencies_apt.sh
+++ b/install_dependencies_apt.sh
@@ -14,5 +14,10 @@ apt-get update
 apt install -y python3-setuptools build-essential python3-dev libnfnetlink-dev libnetfilter-queue-dev libnetfilter-queue1 rsyslog
 service rsyslog restart
 apt-get install -y clamav
+apt-get install software-properties-common
+add-apt-repository ppa:deadsnakes/ppa
+apt-get update
+apt-get install python3.8
+apt-get install python3-pip
 python3 -m pip install -r requirements.txt
 python3 -m pip install git+https://github.com/kti/python-netfilterqueue

--- a/install_dependencies_apt.sh
+++ b/install_dependencies_apt.sh
@@ -18,7 +18,7 @@ apt-get install software-properties-common
 add-apt-repository ppa:deadsnakes/ppa
 apt-get update
 apt-get install python3.8
-apt-get install python3-pip
+apt-get install python3-pip # installing for clean/new/fresh distributions
 python3 -m pip install -r requirements.txt
 python3 -m pip install git+https://github.com/kti/python-netfilterqueue
-python3 -m pip install -r requirements.txt
+python3 -m pip install -r requirements.txt # removes need for extra statement in installation procedure


### PR DESCRIPTION
## Status
**READY**

## Description
Changed ```install_dependencies_apt.sh```
- Included ```pip3``` installation for clean/new/fresh OS or new Virtual Machine
- Repeated ```python3 -m pip install -r requirements.txt``` at end of ```install_dependencies_apt.sh``` so that it doesn't need to be typed again during installation.
- Removed the redundant statements from ```/doc/en-US/user_guide.md``` and ```README.md``` allowing for one time prerequisites installation

## Related PRs
None

## Todos
- [ ] Tests - Tested on a clean Ubuntu image using Docker. Works perfectly. No errors encountered
- [ ] Documentation - Docs have been changed for respective changes in prerequisite installer


## Deploy Notes
**Main Change** - Added statements for pip3 installation and repeated requirement.txt installation  in prerequisite installer.

## Impacted Areas in Application
Number of Files changed = 3

install_dependencies_apt.sh
README.md
/doc/en-US/user_guide.md