### PR TITLE
KeyboardInterrupt handled while args parsing

### DIFF
--- a/securetea/core.py
+++ b/securetea/core.py
@@ -80,7 +80,11 @@ class SecureTea(object):
         self.cred = {}
         args = get_args()
         argsHelper = ArgsHelper(args)
-        args_dict = argsHelper.check_args()
+        try:
+            args_dict = argsHelper.check_args()
+        except KeyboardInterrupt:
+            print('\nKeyboard Interrupt detected. \nQuitting....')
+            exit(0)
         credentials = configurations.SecureTeaConf()
 
         self.cred = args_dict['cred']


### PR DESCRIPTION
## Status
**READY**

## Description
**When using ```Ctrl + C``` while args are being given in interactive mode, the program gives a KeyboardInterrupt exception.**

- Handled that exception and print out a suitable statement

## Related PRs
None

## Todos
- [ ] Tests - Works on Ubuntu image. Tested using Docker. No errors encountered while testing.
- [ ] Documentation - No documentation change needed


## Deploy Notes
Added ```try except``` block on line 83 which catches Interrupt successfully

## Steps to Test or Reproduce
- Install SecureTea and run it using ```securetea``` command
- When it starts asking for credentials, press **```Ctrl+C```** to interrupt
- Before edit, it used to give exception, now, it exits cleanly after printing appropriate message

## Impacted Areas in Application
Number of files affected = 1

 securetea/core.py - added ```try except``` on Line 83 
