### PR TITLE
Updated SecureTea installer and MalwareAnalysis

### DIFF
--- a/install_dependencies_apt.sh
+++ b/install_dependencies_apt.sh
@@ -20,7 +20,8 @@ apt-get -y -qq install python3-pip # python3 and pip installed
 
 apt -y -qq install python3-setuptools build-essential python3-dev libnfnetlink-dev libnetfilter-queue-dev libnetfilter-queue1 rsyslog
 service rsyslog restart
-apt-get -y -qq install -y clamav # dependencies installed
+apt-get -y -qq install -y clamav 
+apt-get -y -qq install pm-utils  # dependencies installed
 
 apt-get -y -qq install binwalk exiftool pngcheck foremost steghide stegosuite # dependencies for steg analysis
 

--- a/securetea/args/args_helper.py
+++ b/securetea/args/args_helper.py
@@ -42,7 +42,7 @@ def iterate_dict(config_dict, default):
         if not skip:
             if not isinstance(item, dict):
                 if int(platform.sys.version_info[0]) < 3:  # if Python 2.X.X
-                    val = raw_input('>> Enter {}: '
+                    val = input('>> Enter {}: '
                                     .format(item)).strip()
                 else:
                     val = str(input('>> Enter {}: '
@@ -238,7 +238,18 @@ class ArgsHelper(object):
                 'mode': 'mode to scan in\n'
                         '(C/c) Continuous Malware Defence Mode\n'
                         '(I/i) Individual file Steganography\n'
-                        '(M/m) Individual file Malware Analysis test\n\t'
+                        '(M/m) Individual file Malware Analysis test\n\t',
+                'filename': 'filename to be scanned - for Individual file Steganography or Individual file Malware Analysis',
+                'stegscan': 'Enter action to take on file\n'
+                            'f/F File Information\n'
+                            's/S View Strings\n'
+                            'e/E Extract Embedded Data\n'
+                            'i/I Run Steganography Tools Individually\n'
+                            'a/A Run all Steganography tools\n'
+                            'q/Q Quit\n'
+                            '\t: ',
+                'passwd': 'Enter Password to use for Steghide or Stegsolve',
+                'virustotal_api_key': 'VirusTotal API Key'
             },
             'default': default
         }
@@ -796,7 +807,7 @@ class ArgsHelper(object):
             if self.args.server_mode and not self.server_mode:
                 self.server_mode = True
                 if int(platform.sys.version_info[0]) < 3:  # if Python 2.X.X
-                    config_decision = raw_input("[!] Do you want to use the saved configuratons? (Y/y): ").strip(" ")
+                    config_decision = input("[!] Do you want to use the saved configuratons? (Y/y): ").strip(" ")
                 else:
                     config_decision = str(input("[!] Do you want to use the saved configuratons? (Y/y): ")).strip(" ")
                 if (config_decision.lower() == "y"):
@@ -875,7 +886,7 @@ class ArgsHelper(object):
             if self.args.system_mode and not self.system_mode:
                 self.system_mode = True
                 if int(platform.sys.version_info[0]) < 3:  # if Python 2.X.X
-                    config_decision = raw_input("[!] Do you want to use the saved configuratons? (Y/y): ").strip(" ")
+                    config_decision = input("[!] Do you want to use the saved configuratons? (Y/y): ").strip(" ")
                 else:
                     config_decision = str(input("[!] Do you want to use the saved configuratons? (Y/y): ")).strip(" ")
                 if (config_decision.lower() == "y"):
@@ -926,7 +937,7 @@ class ArgsHelper(object):
             if self.args.iot_mode and not self.iot_mode:
                 self.iot_mode = True
                 if int(platform.sys.version_info[0]) < 3:  # if Python 2.X.X
-                    config_decision = raw_input("[!] Do you want to use the saved configuratons? (Y/y): ").strip(" ")
+                    config_decision = input("[!] Do you want to use the saved configuratons? (Y/y): ").strip(" ")
                 else:
                     config_decision = str(input("[!] Do you want to use the saved configuratons? (Y/y): ")).strip(" ")
                 if (config_decision.lower() == "y"):

--- a/securetea/args/config.py
+++ b/securetea/args/config.py
@@ -10,7 +10,11 @@ def get_config():
             "access_token_secret": "XXXX"
         },
         "malware_analysis": {
-            "mode": "XXXX"
+            "mode": "XXXX",
+            "filename": "XXXX",
+            "stegscan": "XXXX",
+            "passwd": "XXXX",
+            "virustotal_api_key": "XXXX"
         },
         "telegram": {
             "token": "XXXX",

--- a/securetea/core.py
+++ b/securetea/core.py
@@ -19,7 +19,8 @@ import threading
 from securetea import configurations
 from securetea import logger
 from securetea.lib.notifs import secureTeaTwitter
-from securetea.lib.notifs import secureTeaMalwareAnalysis
+# from securetea.lib.notifs import secureTeaMalwareAnalysis
+from securetea.lib.malware_analysis.malware_analysis_runner import SecureTeaMalwareAnalysis
 from securetea.lib.notifs.secureTeaTelegram import SecureTeaTelegram
 from securetea.lib.notifs import secureTeaSlack
 from securetea.lib.notifs.aws import secureTeaAwsSES
@@ -398,7 +399,7 @@ class SecureTea(object):
                 self.twitter.notify("Welcome to SecureTea..!! Initializing System")
 
         if self.malware_analysis_provided:
-            self.malware_analysis_obj = secureTeaMalwareAnalysis.SecureTeaMalwareAnalysis(self.cred['malware_analysis'])
+            self.malware_analysis_obj = SecureTeaMalwareAnalysis(self.cred['malware_analysis'])
             self.malware_analysis_obj.runner()
 
         if self.telegram_provided:

--- a/securetea/lib/malware_analysis/malware_analysis_runner.py
+++ b/securetea/lib/malware_analysis/malware_analysis_runner.py
@@ -5,21 +5,16 @@ Project:
     ╔═╗┌─┐┌─┐┬ ┬┬─┐┌─┐╔╦╗┌─┐┌─┐
     ╚═╗├┤ │  │ │├┬┘├┤  ║ ├┤ ├─┤
     ╚═╝└─┘└─┘└─┘┴└─└─┘ ╩ └─┘┴ ┴
-    Author: Digvijay Bhosale <digvijayb1729@gmail.com> August 15 2021
+    Author: Digvijay Bhosale <digvijayb1729@gmail.com> November 16 2021
     Version: 1.0
     Module: SecureTea
 """
 
-# This is a vestigal file. 
-# Kindly disregard this.
-
-"""
 from securetea.lib.malware_analysis.fileAnalysis import FileAnalyser
 from securetea.lib.malware_analysis.malwareAnalysis import MalwareAnalysis
 from securetea.lib.malware_analysis.continuous_malware_defence import ContinuousDefence
 from securetea.lib.malware_analysis import globals
 from securetea.lib.malware_analysis.mal_gui import app_runner
-
 
 
 class SecureTeaMalwareAnalysis:
@@ -115,4 +110,3 @@ class SecureTeaMalwareAnalysis:
         else:
             print(globals.WARNING + 'Incorrect option selected' + globals.END)
             return
-"""

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -17,7 +17,7 @@ python3 -m pip uninstall -yr requirements.txt
 echo -e "\e[105m\e[1m Python Requirements Uninstalled \e[0m"
 
 echo -e "\e[105m\e[1m Deleting installed tools \e[0m"
-apt-get -y purge build-essential python3-dev libnfnetlink-dev libnetfilter-queue-dev libnetfilter-queue1 rsyslog clamav # dependencies purgeed
+apt-get -y purge build-essential python3-dev libnfnetlink-dev libnetfilter-queue-dev libnetfilter-queue1 rsyslog clamav pm-utils # dependencies purgeed
 apt-get -y purge binwalk exiftool pngcheck foremost steghide stegosuite curl # dependencies for steg analysis
 echo -e "\e[105m\e[1m Installed tools deleted \e[0m"
 


### PR DESCRIPTION
## Status
**READY**

## Description
- Removed MalwareAnalysis from Notifs as it is not related
- Configuration of malware analysis is now straightforward
- Added suspend command to installer because Ubuntu doesn't ship with it by default

## Todos
- [x] Tests - Tests have been conducted successfully on Ubuntu Machine
- [x] Documentation - No documentation changes needed for this change

## Impacted Areas in Application
List general components of the application that this PR will affect:
- malwareAnalysis will now take all inputs from Main Screen
- pm-utils has been added to installer and uninstaller