### PR TITLE
towncrier added to manage changelogs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,8 @@
+1.0.0 (2023-01-26)
+==================
+
+Bugfixes
+--------
+
+- Fixed a thing! (#1234)
+- Orphan fragments have no ticket ID.

--- a/news/+random.bugfix.rst
+++ b/news/+random.bugfix.rst
@@ -1,0 +1,1 @@
+Orphan fragments have no ticket ID.

--- a/news/.gitignore
+++ b/news/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/news/1234.bugfix
+++ b/news/1234.bugfix
@@ -1,0 +1,1 @@
+Fixed a thing!

--- a/news/7890.doc.rst
+++ b/news/7890.doc.rst
@@ -1,0 +1,1 @@
+Can also be ``rst`` as well!

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,0 +1,3 @@
+[tool.towncrier]
+directory = "news"
+filename = "CHANGES.rst"


### PR DESCRIPTION
A news directory stores the newsfragments and during release when the towncrier is called, CHANGES.rst gets updated and news fragments are removed.


